### PR TITLE
Enables guest access to Explore and Playlists

### DIFF
--- a/doc/logbook/epic&user stories.md
+++ b/doc/logbook/epic&user stories.md
@@ -132,13 +132,20 @@ Scenario: Guest views song library
   And the list should load more songs as I scroll down
 ```
 
-**Story 1.2.2: [Implemented]** As a Guest, I want to search for a song by title or lyrics so that I can find a specific medicine song.
+**Story 1.2.3: [Implemented]** As a Guest, I want to access the Explore and Playlists pages so that I can discover medicine songs without being forced to log in.
 
-```
-Scenario: Search by lyrics
-  Given the library contains a song titled "Water Spirit" with lyrics "Healing water"
-  When I type "Healing" into the search bar
-  Then the song "Water Spirit" should appear in the results
+```gherkin
+Scenario: Guest accesses Explore page
+  Given I am an unauthenticated Guest
+  When I visit the "/explore" page
+  Then I should see the category grid
+  And I should not be redirected to the login page
+
+Scenario: Guest accesses Playlists page
+  Given I am an unauthenticated Guest
+  When I visit the "/playlists" page
+  Then I should see the Playlists overview
+  And I should not be redirected to the login page
 ```
 
 ### Epic 1.3: Basic Song Viewer

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -51,10 +51,12 @@ export async function updateSession(request: NextRequest) {
     if (
         !user &&
         !request.nextUrl.pathname.startsWith("/notes") &&
-        !request.nextUrl.pathname.startsWith("/songs")
+        !request.nextUrl.pathname.startsWith("/songs") &&
+        !request.nextUrl.pathname.startsWith("/explore") &&
+        !request.nextUrl.pathname.startsWith("/playlists")
     ) {
         // This part is for any other protected routes that might be added later
-        // Currently, /notes and /songs are handled in their own logic or allowed
+        // Currently allowed for guests: /, /auth, /login, /notes, /songs, /explore, /playlists
         // But let's keep a tight redirect for anything outside the allowed list
         const url = request.nextUrl.clone();
         url.pathname = "/auth/login";


### PR DESCRIPTION
Allows unauthenticated guests to access the Explore and Playlists pages without being redirected to the login page.

This change enhances the user experience by allowing guests to discover medicine songs before requiring authentication.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation, refactoring, dependency upgrade)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit Tests
- [ ] Manual Verification (describe steps)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
