### PR TITLE
feat: migrate data fetching to Server Components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,10 @@
-'use client';
-
 import SongCard from "@/components/home/SongCard";
-import SongCardSkeleton from "@/components/home/SongCardSkeleton";
-import { fetchSongs } from "@/lib/songUtils";
-import { useQuery } from '@tanstack/react-query';
-import { useAuth } from "@/hooks/useAuth";
+import { fetchSongsServer } from "@/lib/songs/serverQueries";
 import Link from "next/link";
 
-export default function Home() {
-  const { user } = useAuth();
-
-  const { data: songs = [], isLoading } = useQuery({
-    queryKey: ['songs', 'latest'],
-    queryFn: () => fetchSongs(10), // Limit to 10 latest
-  });
-
-  // Home page only shows public songs
-  let displaySongs = songs.filter(song => song.isPublic);
+export default async function Home() {
+  const songs = await fetchSongsServer(10);
+  const displaySongs = songs.filter(song => song.isPublic);
 
   return (
     <main className="flex-1 min-h-0 bg-gray-950">
@@ -67,13 +55,7 @@ export default function Home() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {isLoading ? (
-              <>
-                {[...Array(6)].map((_, i) => (
-                  <SongCardSkeleton key={i} />
-                ))}
-              </>
-            ) : displaySongs.length > 0 ? (
+            {displaySongs.length > 0 ? (
               displaySongs.map((song, index) => (
                 <SongCard
                   key={index}

--- a/app/songs/SongsPageContent.tsx
+++ b/app/songs/SongsPageContent.tsx
@@ -2,7 +2,6 @@
 
 import SearchBar from "@/components/home/SearchBar";
 import SongCard from "@/components/home/SongCard";
-import SongCardSkeleton from "@/components/home/SongCardSkeleton";
 import { Music, Guitar, ChevronDown, Flame, Search, X, Plus } from "lucide-react";
 import { useSidebar } from "@/context/SidebarContext";
 import { useState, useMemo, useEffect } from "react";
@@ -15,11 +14,17 @@ import { getCategoryColor, getCategoryStyles } from "@/lib/uiUtils";
 import { useDeclarativeFilter } from "@/hooks/useDeclarativeFilter";
 import { songFilterConfig, SongFilterState } from "@/lib/songs/filterConfig";
 import TagSelector from "@/components/library/TagSelector";
-import { fetchCategoryTree } from "@/lib/taxonomyUtils";
+import { fetchCategoryTree, type TaxonomyNode } from "@/lib/taxonomyUtils";
+import type { Song } from "@/lib/songUtils";
 
 type SortByType = 'title' | 'newest';
 
-export default function SongsPageContent() {
+interface SongsPageContentProps {
+    initialSongs: Song[];
+    initialTaxonomy: TaxonomyNode[];
+}
+
+export default function SongsPageContent({ initialSongs, initialTaxonomy }: SongsPageContentProps) {
     const searchParams = useSearchParams();
     const router = useRouter(); // needed for clear all button which uses router.push
     const { user } = useAuth();
@@ -36,14 +41,16 @@ export default function SongsPageContent() {
     };
 
     // --- 1. Fetch Data ---
-    const { data: songs = [], isLoading } = useQuery({
+    const { data: songs = [] } = useQuery({
         queryKey: ['songs', 'all'],
         queryFn: () => fetchSongs(),
+        initialData: initialSongs,
     });
 
     const { data: taxonomy = [] } = useQuery({
         queryKey: ['taxonomy'],
         queryFn: fetchCategoryTree,
+        initialData: initialTaxonomy,
     });
 
     // --- 2. Declarative Filter Hook ---
@@ -252,13 +259,7 @@ export default function SongsPageContent() {
                 {/* Song List */}
                 <section>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {isLoading ? (
-                            <>
-                                {[...Array(12)].map((_, i) => (
-                                    <SongCardSkeleton key={i} />
-                                ))}
-                            </>
-                        ) : displaySongs.length > 0 ? (
+                        {displaySongs.length > 0 ? (
                             displaySongs.map((song, index) => (
                                 <SongCard
                                     key={index}

--- a/app/songs/page.tsx
+++ b/app/songs/page.tsx
@@ -1,16 +1,20 @@
-'use client';
-
 import { Suspense } from 'react';
 import SongsPageContent from './SongsPageContent';
+import { fetchSongsServer, fetchCategoryTreeServer } from '@/lib/songs/serverQueries';
 
-export default function SongsPage() {
+export default async function SongsPage() {
+  const [songs, taxonomy] = await Promise.all([
+    fetchSongsServer(),
+    fetchCategoryTreeServer(),
+  ]);
+
   return (
     <Suspense fallback={
       <div className="flex-1 min-h-0 bg-gray-950 flex items-center justify-center">
         <div className="text-gray-500">Loading...</div>
       </div>
     }>
-      <SongsPageContent />
+      <SongsPageContent initialSongs={songs} initialTaxonomy={taxonomy} />
     </Suspense>
   );
 }

--- a/lib/songs/serverQueries.ts
+++ b/lib/songs/serverQueries.ts
@@ -1,0 +1,103 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Song } from "@/lib/songUtils";
+import type { TaxonomyNode } from "@/lib/taxonomyUtils";
+
+/**
+ * Server-side version of fetchSongs — uses the server Supabase client (cookie-aware).
+ * Only import this from Server Components or Server Actions.
+ */
+export async function fetchSongsServer(limit?: number): Promise<Song[]> {
+    const supabase = await createClient();
+
+    let query = supabase
+        .from('compositions')
+        .select(`
+            *,
+            song_versions(key, content_chordpro, melody_notation),
+            song_category_map (
+              categories (
+                name,
+                slug,
+                parent:parent_id (
+                  name,
+                  slug
+                )
+              )
+            )
+        `)
+        .order('created_at', { ascending: false });
+
+    if (limit) {
+        query = query.limit(limit);
+    }
+
+    const { data, error } = await query;
+
+    if (error) throw error;
+
+    return data.map(item => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const version = (item.song_versions as any[])?.[0];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const rawCategories = (item.song_category_map as any[]) || [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const categories = rawCategories.map((mapItem: any) => {
+            const cat = mapItem.categories;
+            return {
+                name: cat.name,
+                slug: cat.slug,
+                parent: cat.parent?.name || null,
+                parentSlug: cat.parent?.slug || null
+            };
+        });
+
+        return {
+            id: item.id,
+            title: item.title,
+            author: item.original_author || "Unknown",
+            songKey: version?.key || null,
+            content: version?.content_chordpro || "",
+            melodyNotation: version?.melody_notation || "",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            isPublic: (item as any).is_public ?? true,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            hasChords: (item as any).has_chords ?? false,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            hasMelody: (item as any).has_melody ?? false,
+            createdAt: item.created_at,
+            color: "red",
+            categories: categories
+        } as Song;
+    });
+}
+
+/**
+ * Server-side version of fetchCategoryTree — uses the server Supabase client.
+ * Only import this from Server Components or Server Actions.
+ */
+export async function fetchCategoryTreeServer(): Promise<TaxonomyNode[]> {
+    const supabase = await createClient();
+
+    const { data: categories, error } = await supabase
+        .from('categories')
+        .select('id, name, slug, emoji, icon_name, parent_id')
+        .order('name');
+
+    if (error) {
+        console.error('Error fetching categories:', JSON.stringify(error, null, 2));
+        return [];
+    }
+
+    if (!categories) return [];
+
+    const parents = categories.filter(c => !c.parent_id);
+    const children = categories.filter(c => c.parent_id);
+
+    return parents.map(parent => ({
+        ...parent,
+        children: children
+            .filter(child => child.parent_id === parent.id)
+            .map(child => ({ ...child, children: [] }))
+    }));
+}


### PR DESCRIPTION
## Summary
- Add `lib/songs/serverQueries.ts` with `fetchSongsServer()` and `fetchCategoryTreeServer()` using the cookie-aware server Supabase client
- Convert `app/page.tsx` to an async Server Component — removes `useQuery`, `useAuth`, and skeleton loading in favour of a direct server-side fetch
- Convert `app/songs/page.tsx` to an async Server Component — pre-fetches songs + taxonomy in parallel with `Promise.all` and passes them as props to `SongsPageContent`
- Update `SongsPageContent` to accept `initialSongs`/`initialTaxonomy` props, wired as `initialData` in React Query — zero loading flash on first render while background refetch is preserved

## Architecture
```
Before: Component → useQuery → fetchSongs() [browser client] → Supabase
After:  Server Component → fetchSongsServer() [server client] → Supabase
                              ↓ props (initialData)
                        Client Component (SongsPageContent) → useQuery [background refetch only]
```

## Test plan
- [x] Home page renders songs without skeleton flash (data in initial HTML)
- [x] `/songs` page renders with song grid immediately — no loading skeletons
- [x] Filters, search, and sort still work correctly (client-side interactivity unchanged)
- [x] React Query background refetch still fires after 5-min staleTime (check Network tab)
- [x] `npx tsc --noEmit` passes (only pre-existing test-file errors, none in modified files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)