### PR TITLE
feat: add Zod validation schemas with tests

### DIFF
--- a/lib/unit-tests/schemas.test.ts
+++ b/lib/unit-tests/schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { uuid, playlistTitle, playlistDescription } from '../validation/schemas';
+
+describe('uuid schema', () => {
+  it('accepts a valid UUID', () => {
+    expect(() => uuid.parse('550e8400-e29b-41d4-a716-446655440000')).not.toThrow();
+  });
+
+  it('rejects a non-UUID string', () => {
+    expect(() => uuid.parse('not-a-uuid')).toThrow();
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => uuid.parse('')).toThrow();
+  });
+});
+
+describe('playlistTitle schema', () => {
+  it('accepts a normal title', () => {
+    expect(playlistTitle.parse('My Ceremony Songs')).toBe('My Ceremony Songs');
+  });
+
+  it('trims whitespace', () => {
+    expect(playlistTitle.parse('  Padded  ')).toBe('Padded');
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => playlistTitle.parse('')).toThrow();
+  });
+
+  it('rejects whitespace-only', () => {
+    expect(() => playlistTitle.parse('   ')).toThrow();
+  });
+
+  it('rejects strings over 200 chars', () => {
+    expect(() => playlistTitle.parse('x'.repeat(201))).toThrow();
+  });
+});
+
+describe('playlistDescription schema', () => {
+  it('accepts a normal description', () => {
+    expect(playlistDescription.parse('Closing songs')).toBe('Closing songs');
+  });
+
+  it('accepts undefined', () => {
+    expect(playlistDescription.parse(undefined)).toBeUndefined();
+  });
+
+  it('rejects strings over 2000 chars', () => {
+    expect(() => playlistDescription.parse('x'.repeat(2001))).toThrow();
+  });
+});

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+/** Validates a UUID string */
+export const uuid = z.string().uuid();
+
+/** Validates a playlist title: trimmed, 1-200 chars */
+export const playlistTitle = z.string().trim().min(1, 'Title required').max(200, 'Title too long');
+
+/** Validates an optional playlist description: max 2000 chars */
+export const playlistDescription = z.string().max(2000, 'Description too long').optional();
+
+/**
+ * Wraps a Zod parse in a try/catch, returning { error: string } on failure.
+ * Use in server actions to avoid throwing.
+ */
+export function safeParse<T>(schema: z.ZodType<T>, value: unknown): { data: T } | { error: string } {
+  const result = schema.safeParse(value);
+  if (result.success) return { data: result.data };
+  return { error: result.error.issues.map(i => i.message).join(', ') };
+}


### PR DESCRIPTION
## Summary
- Add reusable Zod validation schemas (`uuid`, `playlistTitle`, `playlistDescription`) in `lib/validation/schemas.ts`
- Add `safeParse` helper for use in server actions (returns `{ data }` or `{ error }` without throwing)
- Add comprehensive unit tests (11 tests) in `lib/unit-tests/schemas.test.ts`

**Architecture Audit Task 3**