### PR TITLE
feat: Immich-inspired design refresh

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -96,7 +96,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
                   {/* Mobile overlay when sidebar is open */}
                   <SidebarOverlay />
 
-                  <main className="relative overflow-y-auto pb-16 lg:pb-0">
+                  <main className="relative overflow-y-auto pb-16 lg:pb-0 col-start-2">
                     {children}
                   </main>
                 </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,6 +44,7 @@ import { UserPreferencesProvider } from "@/context/UserPreferencesContext";
 import EnvironmentBanner from "@/components/common/EnvironmentBanner";
 import ServiceWorkerRegistrar from "@/components/providers/ServiceWorkerRegistrar";
 import SidebarOverlay from "@/components/common/SidebarOverlay";
+import GlobalSearchModal from "@/components/common/GlobalSearchModal";
 import ThemedToaster from "@/components/providers/ThemedToaster";
 
 // Inline script to prevent flash of wrong theme on load.
@@ -100,6 +101,11 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
                     {children}
                   </main>
                 </div>
+
+                {/* Global search modal (non-/songs pages) */}
+                <Suspense>
+                  <GlobalSearchModal />
+                </Suspense>
 
                 {/* Mobile bottom navigation */}
                 <MobileBottomNav />

--- a/app/library/LibraryTabs.tsx
+++ b/app/library/LibraryTabs.tsx
@@ -41,15 +41,15 @@ export default function LibraryTabs() {
                 <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-2 text-gray-900 dark:text-white">Your Library</h1>
                 <p className="text-slate-500 dark:text-slate-400">Your personal collection of playlists, albums, and artists.</p>
             </header>
-            <div className="flex items-center mb-8">
-                <div className="flex gap-2">
+            <div className="relative mb-8">
+                <div className="flex gap-2 overflow-x-auto scrollbar-none pb-1 -mx-4 px-4 md:mx-0 md:px-0">
                     {tabs.map(({ label, href, icon: Icon }) => {
                         const isActive = pathname === href;
                         return (
                             <Link
                                 key={href}
                                 href={href}
-                                className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-bold transition-all ${
+                                className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-bold transition-all whitespace-nowrap shrink-0 ${
                                     isActive
                                         ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-950'
                                         : 'bg-gray-200/80 dark:bg-gray-800/80 text-gray-500 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white border border-gray-300/50 dark:border-gray-700/50'
@@ -61,6 +61,8 @@ export default function LibraryTabs() {
                         );
                     })}
                 </div>
+                {/* Right-fade scroll hint — hidden on md+ where all tabs fit */}
+                <div className="pointer-events-none absolute inset-y-0 -right-4 md:right-0 w-12 bg-gradient-to-l from-white to-transparent dark:from-gray-950 md:hidden" />
             </div>
         </>
     );

--- a/components/common/GlobalSearchModal.tsx
+++ b/components/common/GlobalSearchModal.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { useSidebar } from '@/context/SidebarContext';
+import { useAuth } from '@/hooks/useAuth';
+import { fetchCategoryTree } from '@/lib/taxonomyUtils';
+import { SONG_KEYS } from '@/lib/songs/queryKeys';
+import SearchFiltersModal from '@/components/library/SearchFiltersModal';
+import type { SongFilterState } from '@/lib/songs/filterConfig';
+
+type SortByType = 'title' | 'author' | 'newest';
+
+/**
+ * Global search modal rendered in the layout for non-/songs pages.
+ * Manages local filter state and navigates to /songs with query params on submit.
+ * On /songs, the page's own SearchFiltersModal takes over.
+ */
+export default function GlobalSearchModal() {
+    const pathname = usePathname();
+    const router = useRouter();
+    const { user } = useAuth();
+    const { searchFiltersOpen, setSearchFiltersOpen } = useSidebar();
+
+    // Don't render on /songs — that page has its own modal with live filtering
+    const isOnSongsPage = pathname === '/songs';
+    if (isOnSongsPage) return null;
+
+    return (
+        <GlobalSearchModalInner
+            isOpen={searchFiltersOpen}
+            onClose={() => setSearchFiltersOpen(false)}
+            isAuthenticated={!!user}
+            router={router}
+            userId={user?.id}
+        />
+    );
+}
+
+function GlobalSearchModalInner({
+    isOpen,
+    onClose,
+    isAuthenticated,
+    router,
+    userId,
+}: {
+    isOpen: boolean;
+    onClose: () => void;
+    isAuthenticated: boolean;
+    router: ReturnType<typeof useRouter>;
+    userId?: string;
+}) {
+    // Fetch taxonomy client-side (cached by React Query)
+    const { data: taxonomy = [] } = useQuery({
+        queryKey: SONG_KEYS.taxonomy(),
+        queryFn: fetchCategoryTree,
+        staleTime: 5 * 60_000,
+        enabled: isOpen, // only fetch when modal is open
+    });
+
+    // Local filter state (not URL-synced)
+    const [localSearch, setLocalSearch] = useState('');
+    const [sortBy, setSortBy] = useState<SortByType>('title');
+    const [state, setState] = useState<SongFilterState>({
+        status: userId ? 'all' : 'public',
+        search: '',
+        category: undefined,
+        tags: [],
+        chords: false,
+        melody: false,
+        favorites: false,
+        mine: false,
+        new: false,
+    });
+
+    const setFilter = useCallback(<K extends keyof SongFilterState>(key: K, value: SongFilterState[K]) => {
+        setState(prev => ({ ...prev, [key]: value }));
+    }, []);
+
+    const resetFilters = useCallback(() => {
+        setState({
+            status: userId ? 'all' : 'public',
+            search: '',
+            category: undefined,
+            tags: [],
+            chords: false,
+            melody: false,
+            favorites: false,
+            mine: false,
+            new: false,
+        });
+    }, [userId]);
+
+    const hasActiveFilters = !!(
+        state.category ||
+        (state.tags?.length ?? 0) > 0 ||
+        state.chords ||
+        state.melody ||
+        state.favorites ||
+        state.mine ||
+        state.new ||
+        (userId && state.status !== 'all')
+    );
+
+    // "Show results" → build URL and navigate to /songs
+    const handleSubmit = useCallback(() => {
+        const params = new URLSearchParams();
+        if (localSearch.trim()) params.set('search', localSearch.trim());
+        if (state.category) params.set('category', state.category);
+        if (state.tags?.length) params.set('tag', state.tags.join(','));
+        if (state.status !== 'all' && state.status !== (userId ? 'all' : 'public')) {
+            params.set('status', state.status);
+        }
+        if (state.chords) params.set('chords', 'true');
+        if (state.melody) params.set('melody', 'true');
+        if (state.favorites) params.set('favorites', 'true');
+        if (state.mine) params.set('mine', 'true');
+        if (state.new) params.set('new', 'true');
+        if (sortBy !== 'title') params.set('sort', sortBy);
+
+        const qs = params.toString();
+        router.push(qs ? `/songs?${qs}` : '/songs');
+        onClose();
+    }, [localSearch, state, sortBy, userId, router, onClose]);
+
+    return (
+        <SearchFiltersModal
+            isOpen={isOpen}
+            onClose={onClose}
+            onSubmit={handleSubmit}
+            state={state}
+            setFilter={setFilter}
+            resetFilters={resetFilters}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            taxonomy={taxonomy}
+            chordsCount={undefined}
+            melodyCount={undefined}
+            favoritesCount={undefined}
+            mineCount={undefined}
+            hasActiveFilters={hasActiveFilters}
+            isAuthenticated={isAuthenticated}
+            localSearch={localSearch}
+            setLocalSearch={setLocalSearch}
+        />
+    );
+}

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -146,9 +146,9 @@ export default function Header() {
             id="app-navbar"
             className="h-[var(--navbar-height)] w-full text-sm sticky top-0 z-50 bg-white/95 dark:bg-gray-950/95 backdrop-blur-md"
         >
-            <div className="grid h-full grid-cols-[auto_auto] sm:grid-cols-[auto_1fr_auto] lg:grid-cols-[16rem_1fr_auto] items-center border-b border-gray-200/60 dark:border-gray-800/60">
+            <div className="grid h-full grid-cols-[1fr_auto] sm:grid-cols-[auto_1fr_auto] lg:grid-cols-[16rem_1fr_auto] items-center border-b border-gray-200/60 dark:border-gray-800/60">
                 {/* Left: Menu button + Logo */}
-                <div className="flex items-center gap-2 mx-4">
+                <div className="flex items-center gap-1.5 mx-4">
                     {/* Mobile menu toggle */}
                     <button
                         onClick={() => setSidebarOpen(true)}
@@ -184,12 +184,7 @@ export default function Header() {
                             className="w-full bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-full py-2.5 pl-10 pr-12 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-red-500/30 focus:border-red-500/40 transition-all relative z-10"
                         />
                         <button
-                            onClick={() => {
-                                if (!isOnSongsPage) {
-                                    router.push('/songs');
-                                }
-                                setSearchFiltersOpen(!searchFiltersOpen);
-                            }}
+                            onClick={() => setSearchFiltersOpen(!searchFiltersOpen)}
                             className={`absolute right-2.5 top-1/2 -translate-y-1/2 p-1.5 rounded-full transition-colors z-10 ${
                                 hasActiveSearchFilters
                                     ? 'text-red-500 bg-red-100 dark:bg-red-500/15'
@@ -251,10 +246,7 @@ export default function Header() {
                 <div className="flex items-center gap-1 md:gap-2 pe-4 lg:pe-6">
                     {/* Mobile: search icon opens search filters modal */}
                     <button
-                        onClick={() => {
-                            if (!isOnSongsPage) router.push('/songs');
-                            setSearchFiltersOpen(true);
-                        }}
+                        onClick={() => setSearchFiltersOpen(true)}
                         className="sm:hidden p-2 rounded-full text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
                         aria-label="Search"
                     >

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -249,14 +249,17 @@ export default function Header() {
 
                 {/* Right: Action buttons */}
                 <div className="flex items-center gap-1 md:gap-2 pe-4 lg:pe-6">
-                    {/* Mobile: search icon navigates to songs page */}
-                    <Link
-                        href="/songs"
+                    {/* Mobile: search icon opens search filters modal */}
+                    <button
+                        onClick={() => {
+                            if (!isOnSongsPage) router.push('/songs');
+                            setSearchFiltersOpen(true);
+                        }}
                         className="sm:hidden p-2 rounded-full text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
                         aria-label="Search"
                     >
                         <Search className="w-5 h-5" />
-                    </Link>
+                    </button>
 
                     {/* Create button with dropdown - desktop only */}
                     {user && (

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -249,14 +249,14 @@ export default function Header() {
 
                 {/* Right: Action buttons */}
                 <div className="flex items-center gap-1 md:gap-2 pe-4 lg:pe-6">
-                    {/* Mobile: search icon that focuses the search bar */}
-                    <button
-                        onClick={() => inputRef.current?.focus()}
+                    {/* Mobile: search icon navigates to songs page */}
+                    <Link
+                        href="/songs"
                         className="sm:hidden p-2 rounded-full text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
                         aria-label="Search"
                     >
                         <Search className="w-5 h-5" />
-                    </button>
+                    </Link>
 
                     {/* Create button with dropdown - desktop only */}
                     {user && (

--- a/components/common/navigation/AccountInfoPanel.tsx
+++ b/components/common/navigation/AccountInfoPanel.tsx
@@ -55,7 +55,7 @@ export function AccountInfoPanel() {
             {/* Avatar trigger */}
             <button
                 onClick={() => setIsOpen(!isOpen)}
-                className="flex ps-2"
+                className="flex"
                 title={`${displayName} (${user.email})`}
             >
                 <div className={`
@@ -83,7 +83,7 @@ export function AccountInfoPanel() {
 
             {/* Dropdown panel */}
             {isOpen && (
-                <div className="absolute z-50 end-0 top-14 w-[min(360px,calc(100vw-40px))] rounded-3xl bg-gray-100 dark:bg-gray-900 shadow-2xl border border-gray-200 dark:border-gray-800 animate-in fade-in slide-in-from-top-2 duration-150">
+                <div className="fixed sm:absolute z-50 right-2 sm:end-0 top-[var(--navbar-height)] sm:top-14 w-[min(360px,calc(100vw-16px))] rounded-3xl bg-gray-100 dark:bg-gray-900 shadow-2xl border border-gray-200 dark:border-gray-800 animate-in fade-in slide-in-from-top-2 duration-150">
                     {/* User identity card */}
                     <div className="mx-4 mt-4 flex flex-col items-center justify-center gap-3 rounded-t-3xl bg-white dark:bg-gray-800/60 p-6">
                         {/* Large avatar */}

--- a/components/library/SearchFiltersModal.tsx
+++ b/components/library/SearchFiltersModal.tsx
@@ -206,7 +206,7 @@ export default function SearchFiltersModal({
                                     onClick={() => setFilter('favorites', !state.favorites)}
                                     icon={<Heart className={`w-4 h-4 ${state.favorites ? 'fill-amber-400' : ''}`} strokeWidth={1.5} />}
                                     label="Favorites"
-                                    count={favoritesCount > 0 ? favoritesCount : undefined}
+                                    count={favoritesCount ? favoritesCount : undefined}
                                     activeColor="amber"
                                 />
                                 <ToggleCard
@@ -214,7 +214,7 @@ export default function SearchFiltersModal({
                                     onClick={() => setFilter('mine', !state.mine)}
                                     icon={<Music className="w-4 h-4" strokeWidth={1.5} />}
                                     label="My Songs"
-                                    count={mineCount > 0 ? mineCount : undefined}
+                                    count={mineCount ? mineCount : undefined}
                                     activeColor="violet"
                                 />
                             </div>

--- a/components/library/SearchFiltersModal.tsx
+++ b/components/library/SearchFiltersModal.tsx
@@ -11,16 +11,17 @@ type SortByType = 'title' | 'author' | 'newest';
 interface SearchFiltersModalProps {
     isOpen: boolean;
     onClose: () => void;
+    onSubmit?: () => void;
     state: SongFilterState;
     setFilter: <K extends keyof SongFilterState>(key: K, value: SongFilterState[K]) => void;
     resetFilters: () => void;
     sortBy: SortByType;
     setSortBy: (val: SortByType) => void;
     taxonomy: TaxonomyNode[];
-    chordsCount: number;
-    melodyCount: number;
-    favoritesCount: number;
-    mineCount: number;
+    chordsCount?: number;
+    melodyCount?: number;
+    favoritesCount?: number;
+    mineCount?: number;
     hasActiveFilters: boolean;
     isAuthenticated: boolean;
     localSearch: string;
@@ -30,6 +31,7 @@ interface SearchFiltersModalProps {
 export default function SearchFiltersModal({
     isOpen,
     onClose,
+    onSubmit,
     state,
     setFilter,
     resetFilters,
@@ -231,7 +233,7 @@ export default function SearchFiltersModal({
                                 disabled={!state.chords && chordsCount === 0}
                                 icon={<Guitar className="w-4 h-4" />}
                                 label="Chords"
-                                count={chordsCount > 0 ? chordsCount : undefined}
+                                count={chordsCount ? chordsCount : undefined}
                                 activeColor="amber"
                             />
                             <ToggleCard
@@ -240,7 +242,7 @@ export default function SearchFiltersModal({
                                 disabled={!state.melody && melodyCount === 0}
                                 icon={<Music className="w-4 h-4" />}
                                 label="Melody"
-                                count={melodyCount > 0 ? melodyCount : undefined}
+                                count={melodyCount ? melodyCount : undefined}
                                 activeColor="emerald"
                             />
                         </div>
@@ -257,7 +259,7 @@ export default function SearchFiltersModal({
                         Clear all
                     </button>
                     <button
-                        onClick={onClose}
+                        onClick={onSubmit ?? onClose}
                         className="flex-1 px-4 py-3 rounded-xl font-bold text-sm text-white bg-red-600 hover:bg-red-500 shadow-lg shadow-red-900/20 transition-all"
                     >
                         Show results


### PR DESCRIPTION
## Summary
- **Layout redesign**: Immich-inspired layout with sticky top navbar, fixed sidebar, and grid-based content area
- **Artists page**: Full artist listing with card design matching playlists, song title previews
- **Search modal**: Global search filters modal available on all pages (navigates to /songs on submit)
- **Library tabs**: Horizontally scrollable on mobile with gradient fade hint
- **Smart playlists**: Show real counts (public/draft) and song title previews
- **Shared CardContent component**: Eliminates duplication across playlist, artist, and smart playlist cards
- **Mobile fixes**: Header spacing, avatar popup positioning, empty page fix (col-start-2), search button opens modal
- **UI polish**: Renamed "Create Playlist" to "New Playlist" with red accent, consistent View All styling

## Test plan
- [x] Verify layout renders correctly on mobile, tablet, and desktop
- [x] Test search modal opens from all pages (not just /songs)
- [x] Test search modal "Show results" navigates to /songs with correct query params
- [x] Verify library tabs scroll horizontally on narrow screens
- [x] Check artists page shows all authors with correct song counts
- [x] Verify smart playlists show real counts and song previews
- [x] Test mobile: no empty pages, avatar popup stays on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)