### PR TITLE
chore: gitignore Supabase Studio snippets and source PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ SUPABASE_LOCAL.md
 # opencode workflow (contains local-only API key)
 .github/workflows/opencode.yml
 .superpowers/
+
+# Supabase Studio local scratch (root-owned "Untitled query" snippets)
+supabase/snippets/
+
+# Source PDFs — the app uses .cho (ChordPro) files, not PDFs
+data/songs/**/*.pdf


### PR DESCRIPTION
- `supabase/snippets/` — root-owned local Supabase Studio scratch ("Untitled query"), not project content.
- `data/songs/**/*.pdf` — import/source material; the app consumes `.cho` (ChordPro) files (0 PDFs were ever tracked).

No code or migrations touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)