### PR TITLE
chore: disable analytics in local Supabase stack

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -366,7 +366,7 @@ deno_version = 2
 # secret_key = "env(SECRET_VALUE)"
 
 [analytics]
-enabled = true
+enabled = false
 port = 54327
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"


### PR DESCRIPTION
Sets `[analytics] enabled = false` in `supabase/config.toml` so `supabase start` skips the local Logflare + vector containers — lighter local dev stack. Local-only; no effect on hosted projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)