### PR TITLE
docs: sync logbook for Jun 9 session

### DIFF
--- a/docs/logbook/master-tasks.md
+++ b/docs/logbook/master-tasks.md
@@ -884,3 +884,12 @@
     - [x] Full MD↔GH sync comparison — fix 6 sync issues (duplicates, title normalisation)
     - [x] Sync MD status: mark 1.1.5, 4.1.1, 4.1.2 as [Implemented]
     - [x] Merge PR #113 into main
+
+- [x] **Session — Jun 9, 2026 (Beta Deployment Guide & Vercel-Migration Tracking)**
+    - [x] Author `docs/beta-deployment.md` (beta cutover off Vercel onto Hetzner VPS + staging Supabase)
+    - [x] Update README deployment row to link the beta deployment guide
+    - [x] Open PR #147 (docs: add beta deployment guide)
+    - [x] Investigate existing Vercel-migration research (none found; context in cloud-infra)
+    - [x] Create cloud-infra#84 — chore: migrate Songbook prod off Vercel (prod-cutover scope)
+    - [x] Cross-link cloud-infra#34 as blocking dependency
+    - [x] Remove stray `issue_draft.md` from main → PR #148

--- a/docs/logbook/master-timetracking.md
+++ b/docs/logbook/master-timetracking.md
@@ -60,4 +60,6 @@
 | **Feb 28** | **Planning**: PWA Stories, Gatekeeper Design, Musician→Profile Setting | ~3.0 Hours | ✅ Completed |
 | **Feb 28** | **Tooling**: sync-stories bug fixes & GitHub issues audit/cleanup | ~1.5 Hours | ✅ Completed |
 
-| **Total** | **Development + AI Collaboration** | **~122.75 Hours** | |
+| **Jun 9** | **Docs/Infra**: Beta Deployment Guide & Vercel-Migration Issue Tracking | ~1.0 Hours | ✅ Completed |
+
+| **Total** | **Development + AI Collaboration** | **~123.75 Hours** | |

--- a/docs/logbook/master-walkthrough.md
+++ b/docs/logbook/master-walkthrough.md
@@ -2215,3 +2215,20 @@ Performed a comprehensive technical audit of the codebase against Next.js 16 and
 - Full MD↔GH sync comparison (all 44 stories): identified 6 sync issues — 5 old-format duplicate issues for 4.1.7–4.1.10 (#89–#92), and #32 title using `1.1.2 - bis` spacing.
 - Closed #89–#92 as superseded by canonical issues; normalized #32 title to `[Story 1.1.2-bis]`.
 - MD status sync: stories 1.1.5, 4.1.1, 4.1.2 pulled from GH and marked `[Implemented]`.
+
+## Session Update (Jun 9, 2026 — Beta Deployment Guide & Vercel-Migration Tracking)
+
+### 1. Beta Deployment Guide (PR #147)
+- Authored `docs/beta-deployment.md` documenting the **beta** cutover off Vercel onto the Hetzner VPS (`cloud-infra`), served at `songbook-beta.bluette.be` against the **staging** Supabase project (`wuigxbpwkpjqqiystbyz`).
+- Captured deploy/update flow (Docker + Traefik, pinned `SONGS_SHA`, rebuild-on-bump), DNS/SSL (`*.bluette.be` wildcard), Supabase auth-redirect setup, and known gaps vs prod.
+- Updated README deployment row: `Vercel` → `Vercel (prod) · self-hosted beta` with a link to the new guide.
+
+### 2. Vercel → EU-Sovereign Migration Tracking
+- Investigated whether a "migration impact" research doc already existed — none found; relevant pieces live in the private `cloud-infra` repo (songbook stack README, ADR-001/002, sovereign-AI research, EU-vendor survey issue #30).
+- Established that the beta is already off Vercel; only the **prod** cutover remains (needs self-hosted/EU prod Supabase).
+- Created **cloud-infra#84** — `chore: migrate Songbook prod off Vercel to the sovereign VPS` (scoped to prod cutover only, Gherkin AC, label `chore`).
+- Cross-linked **cloud-infra#34** (install prod Supabase) as the blocking dependency via a comment.
+
+### 3. Repo Hygiene (PR #148)
+- Found `issue_draft.md` (a leftover create-issue scratch file) accidentally committed to `main` in 10811cb.
+- Removed it on a dedicated `chore/remove-stray-issue-draft` branch → PR #148, keeping it out of the docs PR.


### PR DESCRIPTION
Appends the Jun 9, 2026 session entry to the `docs/logbook/` master files (`/sync-artifacts`):

- **master-walkthrough.md** — `## Session Update (Jun 9, 2026 …)`: beta deployment guide, Vercel→EU-sovereign migration tracking, repo hygiene.
- **master-tasks.md** — Jun 9 task block.
- **master-timetracking.md** — Jun 9 row (~1.0h); total bumped 122.75 → 123.75h.

APPEND-only; no existing history overwritten. (No session brain files existed, so the entry was synthesized from the session's actual work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)