### PR TITLE
[Chore] E2E test overview/matrix + Phase 0 Playwright foundation (#142)

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,16 @@
+# Environment for running E2E tests locally against a local Supabase stack.
+# Copy to `.env.test` (git-ignored) or export these before running Playwright.
+#
+#   npx supabase start        # boots Postgres/Auth/etc. and applies seeds
+#   npx supabase status       # prints the URL + publishable/anon key below
+#
+# Then: npm run test:e2e
+
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<anon/publishable key from `supabase status`>
+
+# Password for the seeded dev accounts (supabase/seeds/01_auth_users.sql).
+NEXT_PUBLIC_DEV_TEST_PASSWORD=sacred-fire-dev
+
+# Optional: point the tests at an already-running server instead of building.
+# E2E_BASE_URL=http://localhost:3000

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,57 @@
+name: E2E (Playwright)
+
+# Phase 0 foundation — see docs/testing/e2e-test-overview.md.
+# Runs the @smoke subset as a PR gate; extend to the full suite as specs land.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - 'feat/**'
+      - 'fix/**'
+      - 'chore/**'
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+      NEXT_PUBLIC_DEV_TEST_PASSWORD: sacred-fire-dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start Supabase (applies migrations + seeds)
+        run: npx supabase start
+
+      - name: Export Supabase publishable key
+        run: |
+          KEY=$(npx supabase status -o json | jq -r '.ANON_KEY // .anon_key // .publishable_key')
+          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$KEY" >> "$GITHUB_ENV"
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run @smoke E2E tests
+        run: npx playwright test --grep @smoke
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,16 +3,18 @@ name: E2E (Playwright)
 # Runs the @smoke E2E subset against the STAGING Supabase project on every push
 # to main or a feature branch. See docs/testing/e2e-test-overview.md.
 #
-# Required repo secrets (reused from deploy-db.yml where possible):
-#   SUPABASE_ACCESS_TOKEN          - Supabase CLI access token (also used to read project API keys)
-#   SUPABASE_PROJECT_ID_STAGING    - staging project ref (e.g. abcdefgh...)
-#   E2E_TEST_PASSWORD              - password for the seeded E2E test accounts on staging
+# Required repo secrets:
+#   SUPABASE_PROJECT_ID_STAGING        - staging project ref (used to derive the URL)
+#   SUPABASE_PUBLISHABLE_KEY_STAGING   - staging anon/publishable key (public; safe as a secret/variable)
+#   E2E_TEST_PASSWORD                 - password for the seeded E2E test accounts on staging
+#
+# Optional:
+#   SUPABASE_URL_STAGING               - full staging URL; overrides the derived https://<ref>.supabase.co
 #
 # NOTE: staging must contain the seeded test accounts (roel.de.meester+{admin,
 # musician,member}@gmail.com) for the per-role auth setup to succeed. Migrations
 # are pushed to staging by deploy-db.yml, but seed data (supabase/seeds/*.sql) is
-# NOT — those accounts must be present on staging (seed it once) or auth.setup
-# will fail.
+# NOT — seed those accounts on staging once, or auth.setup will fail.
 
 on:
   push:
@@ -32,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_ID_STAGING: ${{ secrets.SUPABASE_PROJECT_ID_STAGING }}
       NEXT_PUBLIC_DEV_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
@@ -43,26 +43,32 @@ jobs:
           node-version: 22
           cache: npm
 
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Resolve staging Supabase URL + anon key
+      - name: Configure staging Supabase env
+        env:
+          REF: ${{ secrets.SUPABASE_PROJECT_ID_STAGING }}
+          URL_OVERRIDE: ${{ secrets.SUPABASE_URL_STAGING }}
+          PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY_STAGING }}
+          TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
         run: |
-          REF="$SUPABASE_PROJECT_ID_STAGING"
-          if [ -z "$REF" ]; then
-            echo "::error::SUPABASE_PROJECT_ID_STAGING secret is not set"
+          if [ -n "$URL_OVERRIDE" ]; then
+            URL="$URL_OVERRIDE"
+          elif [ -n "$REF" ]; then
+            URL="https://${REF}.supabase.co"
+          else
+            echo "::error::Set SUPABASE_PROJECT_ID_STAGING (or SUPABASE_URL_STAGING)"
             exit 1
           fi
-          echo "NEXT_PUBLIC_SUPABASE_URL=https://${REF}.supabase.co" >> "$GITHUB_ENV"
-          ANON=$(supabase projects api-keys --project-ref "$REF" --output json \
-            | jq -r '.[] | select(.name=="anon") | .api_key')
-          if [ -z "$ANON" ] || [ "$ANON" = "null" ]; then
-            echo "::error::Could not read staging anon key (check SUPABASE_ACCESS_TOKEN / project ref)"
+          if [ -z "$PUBLISHABLE_KEY" ]; then
+            echo "::error::SUPABASE_PUBLISHABLE_KEY_STAGING secret is not set"
             exit 1
           fi
-          echo "::add-mask::$ANON"
-          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$ANON" >> "$GITHUB_ENV"
+          if [ -z "$TEST_PASSWORD" ]; then
+            echo "::error::E2E_TEST_PASSWORD secret is not set"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_SUPABASE_URL=$URL" >> "$GITHUB_ENV"
+          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$PUBLISHABLE_KEY" >> "$GITHUB_ENV"
+          echo "Staging URL: $URL"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,19 +1,30 @@
 name: E2E (Playwright)
 
-# Phase 0 foundation — see docs/testing/e2e-test-overview.md.
-# Runs the @smoke subset as a PR gate; extend to the full suite as specs land.
+# Runs the @smoke E2E subset against the STAGING Supabase project on every push
+# to main or a feature branch. See docs/testing/e2e-test-overview.md.
+#
+# Required repo secrets (reused from deploy-db.yml where possible):
+#   SUPABASE_ACCESS_TOKEN          - Supabase CLI access token (also used to read project API keys)
+#   SUPABASE_PROJECT_ID_STAGING    - staging project ref (e.g. abcdefgh...)
+#   E2E_TEST_PASSWORD              - password for the seeded E2E test accounts on staging
+#
+# NOTE: staging must contain the seeded test accounts (roel.de.meester+{admin,
+# musician,member}@gmail.com) for the per-role auth setup to succeed. Migrations
+# are pushed to staging by deploy-db.yml, but seed data (supabase/seeds/*.sql) is
+# NOT — those accounts must be present on staging (seed it once) or auth.setup
+# will fail.
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches:
+      - main
       - 'feat/**'
       - 'fix/**'
       - 'chore/**'
 
 concurrency:
-  group: e2e-${{ github.ref }}
+  # One staging E2E run at a time per branch (they share the same remote DB).
+  group: e2e-staging-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -21,8 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
-      NEXT_PUBLIC_DEV_TEST_PASSWORD: sacred-fire-dev
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_ID_STAGING: ${{ secrets.SUPABASE_PROJECT_ID_STAGING }}
+      NEXT_PUBLIC_DEV_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -31,21 +43,36 @@ jobs:
           node-version: 22
           cache: npm
 
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Resolve staging Supabase URL + anon key
+        run: |
+          REF="$SUPABASE_PROJECT_ID_STAGING"
+          if [ -z "$REF" ]; then
+            echo "::error::SUPABASE_PROJECT_ID_STAGING secret is not set"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_SUPABASE_URL=https://${REF}.supabase.co" >> "$GITHUB_ENV"
+          ANON=$(supabase projects api-keys --project-ref "$REF" --output json \
+            | jq -r '.[] | select(.name=="anon") | .api_key')
+          if [ -z "$ANON" ] || [ "$ANON" = "null" ]; then
+            echo "::error::Could not read staging anon key (check SUPABASE_ACCESS_TOKEN / project ref)"
+            exit 1
+          fi
+          echo "::add-mask::$ANON"
+          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$ANON" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: npm ci
-
-      - name: Start Supabase (applies migrations + seeds)
-        run: npx supabase start
-
-      - name: Export Supabase publishable key
-        run: |
-          KEY=$(npx supabase status -o json | jq -r '.ANON_KEY // .anon_key // .publishable_key')
-          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$KEY" >> "$GITHUB_ENV"
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run @smoke E2E tests
+      - name: Run @smoke E2E tests against staging
+        # NEXT_PUBLIC_* are inlined at build time; playwright's webServer runs
+        # `next build && next start`, so the staging env above is baked in.
         run: npx playwright test --grep @smoke
 
       - name: Upload Playwright report

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@
 # testing
 /coverage
 
+# playwright / e2e
+/test-results
+/playwright-report
+/playwright/.cache
+/e2e/.auth
+
 # next.js
 /.next/
 /out/
@@ -33,6 +39,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.test.example
 
 # vercel
 .vercel

--- a/docs/testing/e2e-test-overview.md
+++ b/docs/testing/e2e-test-overview.md
@@ -1,0 +1,238 @@
+# E2E Test Overview & Matrix: Sacred Fire Songs
+
+**Version:** 1.0
+**Status:** Living Document
+**Date:** May 30, 2026
+**Tracking:** GH #142
+
+## Changelog
+
+| Version | Date | Description of Changes |
+| ----- | ----- | ----- |
+| **1.0** | May 30, 2026 | Initial creation. Full E2E test matrix covering all features and variants, derived from `docs/logbook/epic&user stories.md` and a codebase route/component inventory. Tooling recommendation (Playwright) and CI approach included. |
+
+---
+
+## 1. Purpose
+
+This document is the **single source of truth for end-to-end (E2E) test coverage** of Sacred Fire Songs. It enumerates every user-facing feature and its variants, maps each to one or more named E2E scenarios, records the roles affected, and tracks implementation status so coverage gaps are visible and prioritizable.
+
+It is a **living document**: keep it aligned with `docs/logbook/epic&user stories.md` per the project Documentation Sync Policy. When a story is added or a feature changes, add/adjust the corresponding rows here.
+
+### Scope
+
+- **In scope:** browser-level user workflows across all features (auth, song management, library/discovery, viewer, playlists, favorites, gatekeeper tools, account/settings, navigation, PWA), including role variants and edge cases.
+- **Out of scope (covered elsewhere):** pure unit logic already tested by **vitest** in `lib/unit-tests/` (ChordPro parsing, chord utils, query mappers, Zod schemas, guest-favorites logic, playlist action logic). E2E should not duplicate these; it should exercise the *integrated* flow through the UI.
+
+### Current state of testing
+
+- **Unit tests (vitest, v4):** `lib/unit-tests/chordProParsing.test.ts`, `chordUtils.test.ts`, `queries.test.ts`, `songUtils.test.ts`, `playlistActions.test.ts`, `schemas.test.ts`, `useGuestFavorites.test.ts`. Run via `npm test` → `vitest run`.
+- **E2E tests:** **none today.** No Playwright or Cypress config or dependencies exist.
+- **CI:** `.github/workflows/deploy-db.yml` only runs Supabase migrations — there is **no test/lint/E2E job** in CI yet.
+
+---
+
+## 2. Tooling Recommendation
+
+**Recommended framework: [Playwright](https://playwright.dev/).**
+
+Rationale vs. Cypress:
+
+| Criterion | Playwright | Cypress |
+| --- | --- | --- |
+| Next.js App Router fit | Excellent (real browser navigation, route handlers, SSR) | Good |
+| Multi-browser | Chromium, Firefox, WebKit out of the box | Chromium-family + limited WebKit |
+| Mobile emulation | Built-in device descriptors (key for mobile-first UI + bottom nav + wake lock) | Plugin/viewport only |
+| Auth/session reuse | `storageState` makes per-role login fast | Custom commands |
+| Parallelism / CI speed | Native sharding | Paid dashboard for parallel |
+| Network/API mocking | First-class (`route.fulfill`) | First-class |
+
+Mobile emulation and per-role `storageState` matter here because the app is mobile-first (bottom nav, wake lock) and heavily role-gated (Guest/Member/Gatekeeper/Admin).
+
+### Proposed setup
+
+- **Location:** `e2e/` at repo root, specs as `e2e/<feature>.spec.ts`. Shared fixtures/helpers in `e2e/fixtures/`.
+- **Config:** `playwright.config.ts` with projects for `chromium-desktop` and `mobile-chrome` (Pixel 5 descriptor); `webServer` boots `next build && next start` (test against a production build, not `next dev`).
+- **Auth:** a global-setup that logs in one user per role and saves `storageState` per role (leverage the existing dev quick-login / `NEXT_PUBLIC_DEV_TEST_PASSWORD` and mock-role mechanism noted in `hooks/useAuth.tsx`). Guest = no storage state.
+- **Data:** run against a **local Supabase** stack seeded with deterministic fixtures (seed script that creates known songs, playlists, and one account per role). Reset/seed between runs so assertions on counts/titles are stable.
+- **Scripts:** add `"test:e2e": "playwright test"` and `"test:e2e:ui": "playwright test --ui"` to `package.json`.
+
+### CI approach
+
+- Add a GitHub Actions job (e.g. `.github/workflows/e2e.yml`) that: checks out, installs deps, `npx playwright install --with-deps`, starts a local Supabase + seeds, runs `playwright test` sharded, and uploads the HTML report + traces on failure.
+- Gate on PRs to `main` / `feat|fix|chore/*`. Keep it separate from `deploy-db.yml`.
+- Start with `@smoke`-tagged critical-path specs as a required check; run the full suite nightly to keep PR latency low.
+
+---
+
+## 3. Legend
+
+- **Roles:** G = Guest, M = Member, GK = Gatekeeper, A = Admin. (Hierarchy: Guest → Member → Gatekeeper → Admin; `is_musician` is a per-profile flag, not a role.)
+- **Feature status:** ✅ Implemented · ⚠️ Partial/Stub · ❌ Not implemented — reflects the *app feature*, from the codebase inventory.
+- **E2E status:** 🔲 Planned (no spec yet) · 🟡 In progress · ✅ Implemented — every row is 🔲 today since no E2E suite exists.
+- **Priority:** P0 = critical smoke path, P1 = important, P2 = nice-to-have/edge.
+
+---
+
+## 4. Test Matrix
+
+### 4.1 Authentication & Accounts (Epic 1.1 / 3.1)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AUTH-01 | Sign up | New user registers and receives a confirmation/verification link | invalid email; weak/mismatched password; already-registered email; terms unchecked | G | ✅ | 🔲 | P0 | 1.1.4, 3.1.3 |
+| AUTH-02 | Email confirmation | Clicking the confirmation link verifies the account | expired/invalid `token_hash`; `?next` redirect honored | G | ✅ | 🔲 | P0 | `app/auth/confirm`, `callback` |
+| AUTH-03 | Finish registration | Post-signup completion (name, etc.) | skip optional fields | M | ✅ | 🔲 | P1 | `app/auth/finish-registration` |
+| AUTH-04 | Log in | Valid credentials sign in and redirect home | wrong password; unknown email; unverified email; `?next` redirect | G→M | ✅ | 🔲 | P0 | 1.1.4, `login-form.tsx` |
+| AUTH-05 | Log out | Authenticated user logs out; protected UI disappears | session cleared; guest view restored | M/A | ✅ | 🔲 | P0 | 1.1.4 |
+| AUTH-06 | Forgot password | Request reset email for an account | unknown email (no enumeration leak) | G | ✅ | 🔲 | P1 | `forgot-password` |
+| AUTH-07 | Update / reset password | Recovery link lets user set a new password | mismatched confirm; weak password; expired recovery link | G | ✅ | 🔲 | P1 | `update-password` |
+| AUTH-08 | Auth error page | Invalid/expired auth params show friendly error | missing code & token_hash | G | ✅ | 🔲 | P2 | `app/auth/error` |
+| AUTH-09 | Onboarding musician question | New user is asked whether they play an instrument | answer Yes → `is_musician=true`; No/skip → false | M | ⚠️ | 🔲 | P1 | Story 3.5.2 |
+| AUTH-10 | Auth doc accuracy (link not OTP) | Documented flow matches link-based confirm/reset | — | — | ⚠️ | 🔲 | P2 | Story 3.1.3 |
+
+### 4.2 Account & Settings (Epic 3.x)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| ACC-01 | Settings access control | Unauthenticated user is redirected to login | deep-link to `/account/settings` | G | ✅ | 🔲 | P0 | `app/account/settings` |
+| ACC-02 | Profile settings | Update display name and save | empty name; avatar upload | M | ⚠️ | 🔲 | P1 | ProfileSettings |
+| ACC-03 | Security settings | Change password from settings | wrong current password; mismatch | M | ⚠️ | 🔲 | P1 | SecuritySettings |
+| ACC-04 | Privacy settings | Toggle privacy / data options | account deletion confirm | M | ⚠️ | 🔲 | P2 | PrivacySettings |
+| ACC-05 | Preferences / theme | Toggle dark/light/system; persists across reload | no flash-of-wrong-theme on reload | G/M | ✅ | 🔲 | P1 | ThemeToggle |
+| ACC-06 | Musician profile toggle | Enable "I play an instrument" reveals musician features | toggle off hides transpose/chord badges/Chords filter | M | ⚠️ | 🔲 | P1 | Story 3.5.1 |
+
+### 4.3 Song Management (Epic 1.1 / 2.2)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SONG-01 | Add song via form | Create a song with title/author/content and save | missing required fields; validation errors | M/A | ✅ | 🔲 | P0 | 1.1.1 |
+| SONG-02 | Guest add nudge | Guest clicking "Add Song" is prompted to log in / create account | nudge modal vs. silent redirect (see story note) | G | ✅ | 🔲 | P1 | 1.1.5 |
+| SONG-03 | `.cho` file upload | Uploading a file auto-fills title/author/content | `.cho`/`.txt`/`.chordpro`/`.pro`; malformed file; drag-drop vs click | M/A | ✅ | 🔲 | P1 | 1.1.2 |
+| SONG-04 | Smart paste | Pasting ChordPro metadata into lyrics auto-fills fields | title/author/key/capo; partial metadata; content-only | M/A | ✅ | 🔲 | P1 | 1.1.2-bis |
+| SONG-05 | Chords-over-lyrics conversion | Pasted "chords over lyrics" auto-converts to ChordPro | non-chord text not misdetected; key/capo extraction | M/A | ✅ | 🔲 | P1 | 1.1.6 |
+| SONG-06 | Edit song | Owner edits fields and saves | non-owner blocked (RLS); admin override | M(owner)/A | ✅ | 🔲 | P0 | 2.2.1 |
+| SONG-07 | Delete song | Owner/admin deletes a song with confirmation | non-owner has no delete; cancel modal | M(owner)/A | ✅ | 🔲 | P0 | 1.1.3 |
+| SONG-08 | Card delete icon | Hover delete icon on song card (owner/admin) | hidden for non-owner/guest | M(owner)/A | ✅ | 🔲 | P2 | 1.1.4 |
+| SONG-09 | Media links | Attach YouTube/Spotify/SoundCloud URLs; embeds render on detail | invalid URL; multiple embeds | M/A | ✅ | 🔲 | P1 | 1.1.7, 1.3.2/1.3.4 |
+| SONG-10 | Draft auto-save | In-progress add form persists to localStorage and restores | clears after submit; create-mode only | M | ✅ | 🔲 | P2 | Story 1.1.8 |
+| SONG-11 | Public/Draft toggle | Set song visibility on create/edit | draft hidden from guests | M/A | ✅ | 🔲 | P1 | SongForm |
+
+### 4.4 Public Library & Discovery (Epic 1.2 / 2.3)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| LIB-01 | Song list | Guest views the song list | empty state; pagination/infinite scroll | G | ✅ | 🔲 | P0 | 1.2.1 |
+| LIB-02 | Search | Search by title / author / lyrics | cross-page results (see bug #129); debounce; clear restores list | G | ✅ | 🔲 | P0 | 1.2.2 |
+| LIB-03 | Category filter | Filter songs by category (Water, Fire, …) | combine with search; no-results | G | ✅ | 🔲 | P1 | 2.3.1 |
+| LIB-04 | Filter sidebar/modal | Open hamburger/filters and apply | mobile sheet vs desktop | G/M | ✅ | 🔲 | P2 | 2.3.2 |
+| LIB-05 | Category page | Browse a single category page | unknown category slug | G | ✅ | 🔲 | P2 | 2.3.3 |
+| LIB-06 | Sort | Sort by Title / Author / Newest | stable order; combine w/ filters | G | ✅ | 🔲 | P2 | SongsPageContent |
+| LIB-07 | Auth-state refresh | Library updates after login/logout without manual refresh | private/draft appear on login; disappear on logout | G↔M | ✅ | 🔲 | P0 | bug #62 |
+| LIB-08 | Filters: chords/melody/favorites/mine/status | Each filter narrows the list with correct counts | musician-gated Chords filter | M | ✅ | 🔲 | P1 | useSongsFilter |
+| LIB-09 | Artists tab | Browse songs aggregated by author | author with 1 vs many songs | G | ✅ | 🔲 | P2 | `library/artists` |
+| LIB-10 | Albums tab | Placeholder "coming soon" renders | — | G | ⚠️ | 🔲 | P2 | `library/albums` (stub) |
+| LIB-11 | Recently viewed | Auth user sees recently viewed songs | requires auth; records on detail visit | M | ✅ | 🔲 | P1 | `library/recently-viewed` |
+| LIB-12 | New since last visit | Unviewed recent songs surfaced | last_seen tracking | M | ✅ | 🔲 | P2 | NewSinceLastVisit |
+| LIB-13 | Explore/Playlists guest access | Guest can reach Explore & Playlists without login | redirect of `/explore` → `/` | G | ✅ | 🔲 | P2 | 1.2.3 |
+
+### 4.5 Song Viewer (Epic 1.3 / 2.1)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| VIEW-01 | Chords over lyrics | Detail page renders chords aligned above lyrics | songs without chords | G | ✅ | 🔲 | P0 | 1.3.1 |
+| VIEW-02 | Stanza breaks | Double newlines render as visible stanza gaps | — | G | ✅ | 🔲 | P2 | bug #63 |
+| VIEW-03 | Audio/YouTube/SoundCloud embeds | Embeds load and play on detail page | missing/invalid embed | G | ✅ | 🔲 | P1 | 1.3.2 / 1.3.4 |
+| VIEW-04 | Back navigation | Navigate home/back from any page | deep-linked entry | G | ✅ | 🔲 | P2 | 1.3.3 |
+| VIEW-05 | Screen wake lock | Wake lock acquired on detail; released on tab hide; re-acquired on return | unsupported browser graceful no-op | G | ✅ | 🔲 | P1 | 1.3.5 |
+| VIEW-06 | Transpose | Musician transposes chords up/down | wrap A→G#; only when musician enabled | M(musician) | ⚠️ | 🔲 | P1 | 2.1.1 |
+| VIEW-07 | Record view | Visiting detail records a "recently viewed" entry | guest not recorded | M | ✅ | 🔲 | P2 | recordSongView |
+| VIEW-08 | Add-to-playlist from detail | Playlist picker opens and adds the song | unauth → nudge | M | ✅ | 🔲 | P1 | PlaylistPicker |
+
+### 4.6 Favorites (Epic 3.1)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| FAV-01 | Heart a song (member) | Toggle heart; song appears in My Favorites | unheart removes it | M | ✅ | 🔲 | P0 | 3.1.2 |
+| FAV-02 | Guest favorites | Guest hearts persist in localStorage | survive reload; merge on login (if supported) | G | ✅ | 🔲 | P1 | useGuestFavorites |
+| FAV-03 | Favorites filter | Filter library to favorites only | empty favorites state | M | ✅ | 🔲 | P2 | useSongsFilter |
+
+### 4.7 Playlists / Setlists (Epic 4.1)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| PL-01 | Create playlist | Authenticated user creates a playlist inline | empty/duplicate title validation; guest blocked | M | ✅ | 🔲 | P0 | 4.1.x |
+| PL-02 | Add songs via search sheet | Open "+ Add Songs", search, add to playlist | song added at end; duplicate add | M | ✅ | 🔲 | P1 | 4.1.3 |
+| PL-03 | Reorder songs | Drag-drop reorder persists | keyboard reorder; order survives reload | M | ✅ | 🔲 | P1 | PlaylistDetailClient |
+| PL-04 | Remove song | Remove a song from the playlist | last song → empty state | M | ✅ | 🔲 | P2 | PlaylistDetailClient |
+| PL-05 | Rename playlist | Owner renames; persists | non-owner cannot | M(owner) | ✅ | 🔲 | P2 | usePlaylistRename |
+| PL-06 | Delete playlist | Owner deletes with confirmation | cancel | M(owner) | ✅ | 🔲 | P1 | playlistActions |
+| PL-07 | Visibility toggle | Toggle public/private; icon + access change | guest sees public only | M(owner) | ✅ | 🔲 | P1 | 4.1.4 |
+| PL-08 | Access control | Private playlist 404/redirect for non-owner; public viewable by anyone | logged-out vs logged-in | G/M | ✅ | 🔲 | P0 | `playlists/[id]` |
+| PL-09 | Shareable link | Copy public playlist link; toast confirms | private link not shareable | M | ✅ | 🔲 | P2 | 4.1.5 |
+| PL-10 | Description | Add/edit playlist description; persists | empty description | M(owner) | ✅ | 🔲 | P2 | 4.1.6 |
+| PL-11 | Duplicate playlist | Duplicate creates "Copy of …" with same songs/order | navigates to new playlist | M | ✅ | 🔲 | P2 | 4.1.8 |
+| PL-12 | Per-song transpose | Set +/- semitone offset per song in playlist; original unchanged | offset persists on reload | M(musician) | ⚠️ | 🔲 | P2 | 4.1.9 |
+| PL-13 | Cover color/icon | Assign cover color/icon; reflected on card | default grey when unset | M(owner) | ⚠️ | 🔲 | P2 | 4.1.10 |
+| PL-14 | Presentation/ceremony mode | Full-screen present; arrows/swipe advance; wake lock active; Esc exits | mobile swipe vs desktop keys | M | ⚠️ | 🔲 | P1 | 4.1.7 |
+
+### 4.8 Gatekeeper Tools (Epic 3.4)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| GK-01 | Assign Gatekeeper role | Admin promotes a member to Gatekeeper | gains GK tools, keeps member caps | A | ⚠️ | 🔲 | P1 | 3.4.1 |
+| GK-02 | Flag song | GK flags "Needs Improvement"/"Duplicate"; badge + queue + owner notified | resolve flag removes badge | GK | ⚠️ | 🔲 | P1 | 3.4.2 |
+| GK-03 | Edit others' metadata | GK edits key/capo/categories/media of any song | content fields not editable by GK | GK | ⚠️ | 🔲 | P1 | 3.4.3 |
+| GK-04 | Merge duplicates | GK merges duplicate into canonical; version selector; redirects | both contributors credited/notified | GK | ⚠️ | 🔲 | P2 | 3.4.4 |
+| GK-05 | Feature playlist | GK marks public playlist as Featured; appears in curated section | unfeature; none-featured hides section | GK | ⚠️ | 🔲 | P2 | 3.4.5 |
+| GK-06 | Tool visibility gating | GK actions hidden from Member/Guest | — | M/G negative | ⚠️ | 🔲 | P1 | 3.4.1 |
+
+### 4.9 Navigation & Layout (Epic 1.1 / 1.3)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NAV-01 | Mobile bottom nav | Bottom bar shows Home/Search/Library/Create on mobile; hidden on desktop | active-tab highlight | G/M | ✅ | 🔲 | P1 | 1.1.9 |
+| NAV-02 | Avatar vs hamburger | Logged-in mobile shows avatar opening side menu; guest shows hamburger | top-right avatar hidden on mobile | G/M | ✅ | 🔲 | P2 | 1.1.9 |
+| NAV-03 | Create tab guest nudge | Guest tapping Create gets sign-in nudge | — | G | ✅ | 🔲 | P2 | 1.1.9 |
+| NAV-04 | Desktop sidebar | Sidebar links navigate; collapse/expand | active state | M | ✅ | 🔲 | P2 | Sidebar |
+| NAV-05 | Header / global search | Header search opens global search modal | keyboard shortcut; non-song pages | G/M | ✅ | 🔲 | P2 | GlobalSearchModal |
+| NAV-06 | Deep links | Query params (`?search=`, `?tag=`, `?sort=`, `?next=`) restore state | invalid params | G | ✅ | 🔲 | P2 | SongsPageContent |
+
+### 4.10 PWA (Epic 3.3 / 4.5)
+
+| ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| PWA-01 | Manifest / installability | Manifest served; install prompt available; standalone launch | icons 192/512; theme color | G | ✅ | 🔲 | P2 | 3.3.1 |
+| PWA-02 | Branding | Installed app shows icon/name/splash/theme | — | G | ✅ | 🔲 | P2 | 3.3.2 |
+| PWA-03 | Offline fallback | Offline shows branded page; cached pages still load | not-cached route | G | ⚠️ | 🔲 | P2 | 4.5.1 |
+
+---
+
+## 5. Coverage Gaps & Suggested Implementation Order
+
+No E2E specs exist yet, so **every row above is a gap.** Recommended phased rollout:
+
+### Phase 0 — Foundation (enable E2E at all)
+1. Add Playwright, `playwright.config.ts` (chromium-desktop + mobile-chrome), and `webServer` against a production build.
+2. Local-Supabase seed script + per-role `storageState` global setup (Guest/Member/Gatekeeper/Admin).
+3. Wire a CI job (`e2e.yml`) running `@smoke` specs as a required PR check; full suite nightly.
+
+### Phase 1 — P0 smoke paths (critical, must stay green)
+AUTH-01/02/04/05, ACC-01, SONG-01/06/07, LIB-01/02/07, VIEW-01, FAV-01, PL-01/08. These cover "can a user sign in, browse, view, add/edit/delete a song, favorite, and create/access a playlist."
+
+### Phase 2 — P1 core features
+Remaining auth/account (AUTH-03/06/07/09, ACC-02/03/05/06), song import flows (SONG-03/04/05/09/11), discovery (LIB-03/08/11), viewer (VIEW-03/05/06/08), playlists (PL-02/03/06/07/14), gatekeeper core (GK-01/02/03/06), NAV-01.
+
+### Phase 3 — P2 edges & emerging features
+Everything remaining, prioritizing features as they move from ⚠️/❌ to ✅ (presentation mode, per-song transpose, cover color, merge/feature, offline fallback, albums).
+
+### Notes on ⚠️/❌ features
+Rows marked ⚠️ (musician transpose, onboarding question, presentation mode, per-song transpose, cover color, gatekeeper suite, offline, avatar upload) should have their E2E spec authored **together with** the feature implementation, not before — link each to its story/issue so this matrix updates as those land.
+
+---
+
+## 6. Maintenance
+
+- When a new user story is added to `docs/logbook/epic&user stories.md`, add a matching matrix row here (status 🔲) in the same PR.
+- When a feature's E2E spec lands, flip its E2E status to ✅ and link the spec path.
+- Treat this matrix as the **definition-of-done checklist** for E2E coverage; a feature is not "fully tested" until its P0/P1 rows are ✅.

--- a/docs/testing/e2e-test-overview.md
+++ b/docs/testing/e2e-test-overview.md
@@ -1,6 +1,6 @@
 # E2E Test Overview & Matrix: Sacred Fire Songs
 
-**Version:** 1.0
+**Version:** 1.1
 **Status:** Living Document
 **Date:** May 30, 2026
 **Tracking:** GH #142
@@ -10,6 +10,7 @@
 | Version | Date | Description of Changes |
 | ----- | ----- | ----- |
 | **1.0** | May 30, 2026 | Initial creation. Full E2E test matrix covering all features and variants, derived from `docs/logbook/epic&user stories.md` and a codebase route/component inventory. Tooling recommendation (Playwright) and CI approach included. |
+| **1.1** | May 30, 2026 | Phase 0 scaffolded: added Playwright (`playwright.config.ts`, `@playwright/test`), per-role auth setup (`e2e/auth.setup.ts`), seeded-account fixtures, P0 `@smoke` specs (`e2e/tests/smoke.spec.ts`), CI workflow (`.github/workflows/e2e.yml`), and npm scripts. Flipped scaffolded smoke rows (AUTH-04, ACC-01, LIB-01, LIB-07, VIEW-01) to 🟡. |
 
 ---
 
@@ -27,8 +28,8 @@ It is a **living document**: keep it aligned with `docs/logbook/epic&user storie
 ### Current state of testing
 
 - **Unit tests (vitest, v4):** `lib/unit-tests/chordProParsing.test.ts`, `chordUtils.test.ts`, `queries.test.ts`, `songUtils.test.ts`, `playlistActions.test.ts`, `schemas.test.ts`, `useGuestFavorites.test.ts`. Run via `npm test` → `vitest run`.
-- **E2E tests:** **none today.** No Playwright or Cypress config or dependencies exist.
-- **CI:** `.github/workflows/deploy-db.yml` only runs Supabase migrations — there is **no test/lint/E2E job** in CI yet.
+- **E2E tests:** **Phase 0 scaffolded** (this branch). Playwright is wired up (`playwright.config.ts`, `e2e/`), with per-role auth setup and a handful of P0 `@smoke` specs. Specs are authored but **not yet verified against a running app + seeded Supabase** — that verification happens once CI (or a dev) runs them. See `e2e/README.md`.
+- **CI:** `.github/workflows/deploy-db.yml` runs Supabase migrations; **`.github/workflows/e2e.yml`** (new) boots a seeded local Supabase and runs the `@smoke` subset on PRs.
 
 ---
 
@@ -83,7 +84,7 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 | AUTH-01 | Sign up | New user registers and receives a confirmation/verification link | invalid email; weak/mismatched password; already-registered email; terms unchecked | G | ✅ | 🔲 | P0 | 1.1.4, 3.1.3 |
 | AUTH-02 | Email confirmation | Clicking the confirmation link verifies the account | expired/invalid `token_hash`; `?next` redirect honored | G | ✅ | 🔲 | P0 | `app/auth/confirm`, `callback` |
 | AUTH-03 | Finish registration | Post-signup completion (name, etc.) | skip optional fields | M | ✅ | 🔲 | P1 | `app/auth/finish-registration` |
-| AUTH-04 | Log in | Valid credentials sign in and redirect home | wrong password; unknown email; unverified email; `?next` redirect | G→M | ✅ | 🔲 | P0 | 1.1.4, `login-form.tsx` |
+| AUTH-04 | Log in | Valid credentials sign in and redirect home | wrong password; unknown email; unverified email; `?next` redirect | G→M | ✅ | 🟡 | P0 | 1.1.4, `login-form.tsx` |
 | AUTH-05 | Log out | Authenticated user logs out; protected UI disappears | session cleared; guest view restored | M/A | ✅ | 🔲 | P0 | 1.1.4 |
 | AUTH-06 | Forgot password | Request reset email for an account | unknown email (no enumeration leak) | G | ✅ | 🔲 | P1 | `forgot-password` |
 | AUTH-07 | Update / reset password | Recovery link lets user set a new password | mismatched confirm; weak password; expired recovery link | G | ✅ | 🔲 | P1 | `update-password` |
@@ -95,7 +96,7 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 
 | ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| ACC-01 | Settings access control | Unauthenticated user is redirected to login | deep-link to `/account/settings` | G | ✅ | 🔲 | P0 | `app/account/settings` |
+| ACC-01 | Settings access control | Unauthenticated user is redirected to login | deep-link to `/account/settings` | G | ✅ | 🟡 | P0 | `app/account/settings` |
 | ACC-02 | Profile settings | Update display name and save | empty name; avatar upload | M | ⚠️ | 🔲 | P1 | ProfileSettings |
 | ACC-03 | Security settings | Change password from settings | wrong current password; mismatch | M | ⚠️ | 🔲 | P1 | SecuritySettings |
 | ACC-04 | Privacy settings | Toggle privacy / data options | account deletion confirm | M | ⚠️ | 🔲 | P2 | PrivacySettings |
@@ -122,13 +123,13 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 
 | ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| LIB-01 | Song list | Guest views the song list | empty state; pagination/infinite scroll | G | ✅ | 🔲 | P0 | 1.2.1 |
+| LIB-01 | Song list | Guest views the song list | empty state; pagination/infinite scroll | G | ✅ | 🟡 | P0 | 1.2.1 |
 | LIB-02 | Search | Search by title / author / lyrics | cross-page results (see bug #129); debounce; clear restores list | G | ✅ | 🔲 | P0 | 1.2.2 |
 | LIB-03 | Category filter | Filter songs by category (Water, Fire, …) | combine with search; no-results | G | ✅ | 🔲 | P1 | 2.3.1 |
 | LIB-04 | Filter sidebar/modal | Open hamburger/filters and apply | mobile sheet vs desktop | G/M | ✅ | 🔲 | P2 | 2.3.2 |
 | LIB-05 | Category page | Browse a single category page | unknown category slug | G | ✅ | 🔲 | P2 | 2.3.3 |
 | LIB-06 | Sort | Sort by Title / Author / Newest | stable order; combine w/ filters | G | ✅ | 🔲 | P2 | SongsPageContent |
-| LIB-07 | Auth-state refresh | Library updates after login/logout without manual refresh | private/draft appear on login; disappear on logout | G↔M | ✅ | 🔲 | P0 | bug #62 |
+| LIB-07 | Auth-state refresh | Library updates after login/logout without manual refresh | private/draft appear on login; disappear on logout | G↔M | ✅ | 🟡 | P0 | bug #62 |
 | LIB-08 | Filters: chords/melody/favorites/mine/status | Each filter narrows the list with correct counts | musician-gated Chords filter | M | ✅ | 🔲 | P1 | useSongsFilter |
 | LIB-09 | Artists tab | Browse songs aggregated by author | author with 1 vs many songs | G | ✅ | 🔲 | P2 | `library/artists` |
 | LIB-10 | Albums tab | Placeholder "coming soon" renders | — | G | ⚠️ | 🔲 | P2 | `library/albums` (stub) |
@@ -140,7 +141,7 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 
 | ID | Feature | Scenario | Variants / Edge cases | Roles | Feat | E2E | Pri | Ref |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| VIEW-01 | Chords over lyrics | Detail page renders chords aligned above lyrics | songs without chords | G | ✅ | 🔲 | P0 | 1.3.1 |
+| VIEW-01 | Chords over lyrics | Detail page renders chords aligned above lyrics | songs without chords | G | ✅ | 🟡 | P0 | 1.3.1 |
 | VIEW-02 | Stanza breaks | Double newlines render as visible stanza gaps | — | G | ✅ | 🔲 | P2 | bug #63 |
 | VIEW-03 | Audio/YouTube/SoundCloud embeds | Embeds load and play on detail page | missing/invalid embed | G | ✅ | 🔲 | P1 | 1.3.2 / 1.3.4 |
 | VIEW-04 | Back navigation | Navigate home/back from any page | deep-linked entry | G | ✅ | 🔲 | P2 | 1.3.3 |
@@ -212,10 +213,12 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 
 No E2E specs exist yet, so **every row above is a gap.** Recommended phased rollout:
 
-### Phase 0 — Foundation (enable E2E at all)
-1. Add Playwright, `playwright.config.ts` (chromium-desktop + mobile-chrome), and `webServer` against a production build.
-2. Local-Supabase seed script + per-role `storageState` global setup (Guest/Member/Gatekeeper/Admin).
-3. Wire a CI job (`e2e.yml`) running `@smoke` specs as a required PR check; full suite nightly.
+### Phase 0 — Foundation (enable E2E at all) — ✅ scaffolded (GH #142)
+1. ✅ Added Playwright + `@playwright/test`, `playwright.config.ts` (chromium-desktop + mobile-chrome), `webServer` against a production build.
+2. ✅ Per-role `storageState` setup (`e2e/auth.setup.ts`) against the existing seeded accounts (admin/musician/member). _Gatekeeper account not seeded yet — add when GK specs land._ Local Supabase already seeds via `supabase/seeds/*.sql`.
+3. ✅ CI job (`.github/workflows/e2e.yml`) runs `@smoke` specs on PRs. _Follow-up: make it a required check and add a nightly full-suite run._
+
+> **Remaining to fully "close" Phase 0:** verify the suite actually runs green in CI against a booted Supabase (the specs are authored but unverified in this environment), then mark the 🟡 rows ✅.
 
 ### Phase 1 — P0 smoke paths (critical, must stay green)
 AUTH-01/02/04/05, ACC-01, SONG-01/06/07, LIB-01/02/07, VIEW-01, FAV-01, PL-01/08. These cover "can a user sign in, browse, view, add/edit/delete a song, favorite, and create/access a playlist."

--- a/docs/testing/e2e-test-overview.md
+++ b/docs/testing/e2e-test-overview.md
@@ -1,6 +1,6 @@
 # E2E Test Overview & Matrix: Sacred Fire Songs
 
-**Version:** 1.1
+**Version:** 1.2
 **Status:** Living Document
 **Date:** May 30, 2026
 **Tracking:** GH #142
@@ -11,6 +11,7 @@
 | ----- | ----- | ----- |
 | **1.0** | May 30, 2026 | Initial creation. Full E2E test matrix covering all features and variants, derived from `docs/logbook/epic&user stories.md` and a codebase route/component inventory. Tooling recommendation (Playwright) and CI approach included. |
 | **1.1** | May 30, 2026 | Phase 0 scaffolded: added Playwright (`playwright.config.ts`, `@playwright/test`), per-role auth setup (`e2e/auth.setup.ts`), seeded-account fixtures, P0 `@smoke` specs (`e2e/tests/smoke.spec.ts`), CI workflow (`.github/workflows/e2e.yml`), and npm scripts. Flipped scaffolded smoke rows (AUTH-04, ACC-01, LIB-01, LIB-07, VIEW-01) to 🟡. |
+| **1.2** | May 30, 2026 | CI now runs `@smoke` against the **staging** Supabase on push to `main`/`feat|fix|chore/**` (resolves staging URL + anon key via the CLI) instead of a local stack. Documented the staging seed-data caveat and read-only/shared-DB constraints. |
 
 ---
 
@@ -29,7 +30,7 @@ It is a **living document**: keep it aligned with `docs/logbook/epic&user storie
 
 - **Unit tests (vitest, v4):** `lib/unit-tests/chordProParsing.test.ts`, `chordUtils.test.ts`, `queries.test.ts`, `songUtils.test.ts`, `playlistActions.test.ts`, `schemas.test.ts`, `useGuestFavorites.test.ts`. Run via `npm test` → `vitest run`.
 - **E2E tests:** **Phase 0 scaffolded** (this branch). Playwright is wired up (`playwright.config.ts`, `e2e/`), with per-role auth setup and a handful of P0 `@smoke` specs. Specs are authored but **not yet verified against a running app + seeded Supabase** — that verification happens once CI (or a dev) runs them. See `e2e/README.md`.
-- **CI:** `.github/workflows/deploy-db.yml` runs Supabase migrations; **`.github/workflows/e2e.yml`** (new) boots a seeded local Supabase and runs the `@smoke` subset on PRs.
+- **CI:** `.github/workflows/deploy-db.yml` runs Supabase migrations; **`.github/workflows/e2e.yml`** (new) runs the `@smoke` subset against the **staging** Supabase project on every push to `main` / `feat|fix|chore/**`.
 
 ---
 
@@ -60,9 +61,9 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 
 ### CI approach
 
-- Add a GitHub Actions job (e.g. `.github/workflows/e2e.yml`) that: checks out, installs deps, `npx playwright install --with-deps`, starts a local Supabase + seeds, runs `playwright test` sharded, and uploads the HTML report + traces on failure.
-- Gate on PRs to `main` / `feat|fix|chore/*`. Keep it separate from `deploy-db.yml`.
-- Start with `@smoke`-tagged critical-path specs as a required check; run the full suite nightly to keep PR latency low.
+- `.github/workflows/e2e.yml` runs on **push** to `main` / `feat|fix|chore/**` and tests against the **staging** Supabase project (reusing `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROJECT_ID_STAGING`; the staging anon key is resolved at runtime via `supabase projects api-keys`). It installs deps + Chromium, runs the `@smoke` subset, and uploads the HTML report.
+- **Staging caveat:** seed data (`supabase/seeds/*.sql`) is **not** auto-applied to staging by `deploy-db.yml` (only migrations). The seeded E2E accounts must exist on staging, or `auth.setup.ts` fails. Also, because branches share one staging DB, keep CI specs read-only/idempotent (the current `@smoke` set is) and serialize runs (the workflow uses a per-ref concurrency group).
+- For fully isolated runs, an alternative is booting a local Supabase in CI (`supabase start`) instead of staging — kept as a future option. Consider promoting `@smoke` to a required status check and adding a nightly full-suite run.
 
 ---
 

--- a/docs/testing/e2e-test-overview.md
+++ b/docs/testing/e2e-test-overview.md
@@ -1,8 +1,8 @@
 # E2E Test Overview & Matrix: Sacred Fire Songs
 
-**Version:** 1.2
+**Version:** 1.3
 **Status:** Living Document
-**Date:** May 30, 2026
+**Date:** May 31, 2026
 **Tracking:** GH #142
 
 ## Changelog
@@ -12,6 +12,7 @@
 | **1.0** | May 30, 2026 | Initial creation. Full E2E test matrix covering all features and variants, derived from `docs/logbook/epic&user stories.md` and a codebase route/component inventory. Tooling recommendation (Playwright) and CI approach included. |
 | **1.1** | May 30, 2026 | Phase 0 scaffolded: added Playwright (`playwright.config.ts`, `@playwright/test`), per-role auth setup (`e2e/auth.setup.ts`), seeded-account fixtures, P0 `@smoke` specs (`e2e/tests/smoke.spec.ts`), CI workflow (`.github/workflows/e2e.yml`), and npm scripts. Flipped scaffolded smoke rows (AUTH-04, ACC-01, LIB-01, LIB-07, VIEW-01) to 🟡. |
 | **1.2** | May 30, 2026 | CI now runs `@smoke` against the **staging** Supabase on push to `main`/`feat|fix|chore/**` (resolves staging URL + anon key via the CLI) instead of a local stack. Documented the staging seed-data caveat and read-only/shared-DB constraints. |
+| **1.3** | May 31, 2026 | CI hardening: the staging anon key is now read from the `SUPABASE_PUBLISHABLE_KEY_STAGING` secret instead of the `supabase projects api-keys` CLI lookup (which returned no key and failed the run). Dropped the Supabase CLI step; URL derived from the project ref. Documented required secrets. |
 
 ---
 
@@ -61,7 +62,7 @@ Mobile emulation and per-role `storageState` matter here because the app is mobi
 
 ### CI approach
 
-- `.github/workflows/e2e.yml` runs on **push** to `main` / `feat|fix|chore/**` and tests against the **staging** Supabase project (reusing `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROJECT_ID_STAGING`; the staging anon key is resolved at runtime via `supabase projects api-keys`). It installs deps + Chromium, runs the `@smoke` subset, and uploads the HTML report.
+- `.github/workflows/e2e.yml` runs on **push** to `main` / `feat|fix|chore/**` and tests against the **staging** Supabase project. It derives the staging URL from `SUPABASE_PROJECT_ID_STAGING` and reads the (public) anon key from the `SUPABASE_PUBLISHABLE_KEY_STAGING` secret; `E2E_TEST_PASSWORD` provides the seeded-account password. It installs deps + Chromium, runs the `@smoke` subset, and uploads the HTML report.
 - **Staging caveat:** seed data (`supabase/seeds/*.sql`) is **not** auto-applied to staging by `deploy-db.yml` (only migrations). The seeded E2E accounts must exist on staging, or `auth.setup.ts` fails. Also, because branches share one staging DB, keep CI specs read-only/idempotent (the current `@smoke` set is) and serialize runs (the workflow uses a per-ref concurrency group).
 - For fully isolated runs, an alternative is booting a local Supabase in CI (`supabase start`) instead of staging — kept as a future option. Consider promoting `@smoke` to a required status check and adding a nightly full-suite run.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,60 @@
+# E2E Tests (Playwright)
+
+End-to-end tests for Sacred Fire Songs. The full coverage plan lives in
+[`docs/testing/e2e-test-overview.md`](../docs/testing/e2e-test-overview.md);
+this directory is the **Phase 0 foundation** plus the first P0 smoke specs.
+
+## Layout
+
+```
+e2e/
+  auth.setup.ts        # logs in each seeded role, saves storageState to .auth/
+  fixtures/roles.ts    # seeded accounts + storage-state paths
+  tests/smoke.spec.ts  # P0 @smoke happy-path checks
+  .auth/               # generated per-role sessions (git-ignored)
+```
+
+## Running locally
+
+```bash
+# 1. Boot a local Supabase stack (applies migrations + seeds)
+npx supabase start
+
+# 2. Configure env (see .env.test.example) — grab the key from:
+npx supabase status
+
+export NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+export NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<key from supabase status>
+export NEXT_PUBLIC_DEV_TEST_PASSWORD=sacred-fire-dev
+
+# 3. Install Playwright browsers (first time only)
+npx playwright install --with-deps chromium
+
+# 4. Run
+npm run test:e2e          # headless, builds + starts the app
+npm run test:e2e:ui       # interactive UI mode
+npx playwright test --grep @smoke   # P0 smoke subset only
+```
+
+The config builds a **production** bundle (`next build && next start`) and runs
+against it, so timing and bundling match reality. To test an already-running
+server, set `E2E_BASE_URL`.
+
+## Roles
+
+`auth.setup.ts` signs in the seeded `admin`, `musician`, and `member` accounts
+and persists their sessions. A spec opts into a role with:
+
+```ts
+import { ROLES } from '../fixtures/roles';
+test.use({ storageState: ROLES.member.storage });
+```
+
+Guest specs use no `storageState`. There is **no seeded Gatekeeper account yet**
+— add one (seed + `fixtures/roles.ts` + `auth.setup.ts`) when GK-* specs are
+implemented.
+
+## CI
+
+`.github/workflows/e2e.yml` runs the `@smoke` subset on PRs. See that file for
+the Supabase bootstrap + key extraction steps.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -56,5 +56,15 @@ implemented.
 
 ## CI
 
-`.github/workflows/e2e.yml` runs the `@smoke` subset on PRs. See that file for
-the Supabase bootstrap + key extraction steps.
+`.github/workflows/e2e.yml` runs the `@smoke` subset against the **staging**
+Supabase project on every push to `main` / `feat|fix|chore/**`. It resolves the
+staging URL + anon key at runtime from these repo secrets:
+
+- `SUPABASE_ACCESS_TOKEN` (also used by `deploy-db.yml`)
+- `SUPABASE_PROJECT_ID_STAGING`
+- `E2E_TEST_PASSWORD` — password for the seeded E2E accounts on staging
+
+> ⚠️ Staging must contain the seeded test accounts. `deploy-db.yml` pushes
+> migrations to staging but **not** seed data (`supabase/seeds/*.sql`), so seed
+> those accounts on staging once, or `auth.setup.ts` will fail. Keep CI specs
+> read-only — branches share one staging DB.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -57,12 +57,13 @@ implemented.
 ## CI
 
 `.github/workflows/e2e.yml` runs the `@smoke` subset against the **staging**
-Supabase project on every push to `main` / `feat|fix|chore/**`. It resolves the
-staging URL + anon key at runtime from these repo secrets:
+Supabase project on every push to `main` / `feat|fix|chore/**`. It derives the
+staging URL from the project ref and reads the (public) anon key from a secret:
 
-- `SUPABASE_ACCESS_TOKEN` (also used by `deploy-db.yml`)
-- `SUPABASE_PROJECT_ID_STAGING`
+- `SUPABASE_PROJECT_ID_STAGING` — staging project ref (URL = `https://<ref>.supabase.co`)
+- `SUPABASE_PUBLISHABLE_KEY_STAGING` — staging anon/publishable key (public; safe as a secret)
 - `E2E_TEST_PASSWORD` — password for the seeded E2E accounts on staging
+- `SUPABASE_URL_STAGING` — _optional_ full URL override
 
 > ⚠️ Staging must contain the seeded test accounts. `deploy-db.yml` pushes
 > migrations to staging but **not** seed data (`supabase/seeds/*.sql`), so seed

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,38 @@
+import { test as setup, expect } from '@playwright/test';
+import fs from 'fs';
+import { ROLES, TEST_PASSWORD, STORAGE_DIR, type RoleKey } from './fixtures/roles';
+
+/**
+ * Authenticates once per seeded role and saves the session (cookies +
+ * localStorage) to e2e/.auth/<role>.json. Specs then opt into a role via
+ *   test.use({ storageState: ROLES.member.storage })
+ * Guest specs use no storageState.
+ *
+ * Login is driven through the real UI (/auth/login → "Sign in with password")
+ * so the Supabase SSR cookie session is captured exactly as a browser sets it.
+ */
+
+setup.beforeAll(() => {
+  fs.mkdirSync(STORAGE_DIR, { recursive: true });
+});
+
+for (const role of Object.keys(ROLES) as RoleKey[]) {
+  setup(`authenticate as ${role}`, async ({ page }) => {
+    const { email, storage } = ROLES[role];
+
+    await page.goto('/auth/login');
+
+    // The form defaults to magic-link mode; switch to password mode.
+    await page.getByRole('button', { name: 'Sign in with password' }).click();
+
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+
+    // Successful login redirects to the home page.
+    await page.waitForURL((url) => url.pathname === '/');
+    await expect(page.getByText(/an error occurred/i)).toHaveCount(0);
+
+    await page.context().storageState({ path: storage });
+  });
+}

--- a/e2e/fixtures/roles.ts
+++ b/e2e/fixtures/roles.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+
+/**
+ * Storage-state directory for per-role authenticated sessions.
+ * Populated by e2e/auth.setup.ts and git-ignored.
+ * Resolved from the repo root (Playwright runs from there).
+ */
+export const STORAGE_DIR = path.join(process.cwd(), 'e2e', '.auth');
+
+/**
+ * Seeded local-dev accounts (see supabase/seeds/01_auth_users.sql &
+ * 02_profiles.sql). All share the same dev password.
+ *
+ * NOTE: there is no seeded Gatekeeper account yet. When gatekeeper seed data
+ * lands (Epic 3.4), add it here and to auth.setup.ts so GK-* specs can run.
+ */
+export const ROLES = {
+  admin: {
+    email: 'roel.de.meester+admin@gmail.com',
+    storage: path.join(STORAGE_DIR, 'admin.json'),
+  },
+  musician: {
+    email: 'roel.de.meester+musician@gmail.com',
+    storage: path.join(STORAGE_DIR, 'musician.json'),
+  },
+  member: {
+    email: 'roel.de.meester+member@gmail.com',
+    storage: path.join(STORAGE_DIR, 'member.json'),
+  },
+} as const;
+
+export type RoleKey = keyof typeof ROLES;
+
+/** Dev password from env, with the seeded default as a fallback. */
+export const TEST_PASSWORD =
+  process.env.NEXT_PUBLIC_DEV_TEST_PASSWORD ?? 'sacred-fire-dev';

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { ROLES } from '../fixtures/roles';
+
+/**
+ * P0 smoke paths from the E2E matrix (docs/testing/e2e-test-overview.md).
+ * Tagged @smoke so CI can gate PRs on this subset and run the full suite later.
+ *
+ * These are intentionally shallow happy-path checks — the foundation that must
+ * always stay green. Deeper variants/edge cases are tracked as follow-up specs.
+ */
+
+test.describe('Guest smoke @smoke', () => {
+  // No storageState → unauthenticated guest.
+
+  test('LIB-01: guest can load the song library', async ({ page }) => {
+    await page.goto('/songs');
+    // The songs page renders a search field and at least one song link.
+    await expect(page).toHaveURL(/\/songs/);
+    await expect(page.locator('a[href^="/songs/"]').first()).toBeVisible();
+  });
+
+  test('VIEW-01: guest can open a song detail page', async ({ page }) => {
+    await page.goto('/songs');
+    await page.locator('a[href^="/songs/"]').first().click();
+    await expect(page).toHaveURL(/\/songs\/[^/]+$/);
+  });
+
+  test('ACC-01: settings redirects unauthenticated user to login', async ({ page }) => {
+    await page.goto('/account/settings');
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+});
+
+test.describe('Member smoke @smoke', () => {
+  test.use({ storageState: ROLES.member.storage });
+
+  test('AUTH-04: authenticated member reaches account settings', async ({ page }) => {
+    await page.goto('/account/settings');
+    // Should NOT bounce to login when authenticated.
+    await expect(page).toHaveURL(/\/account\/settings/);
+  });
+
+  test('LIB-07: authenticated member sees the library', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL((url) => url.pathname === '/');
+  });
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -16,12 +16,12 @@ test.describe('Guest smoke @smoke', () => {
     await page.goto('/songs');
     // The songs page renders a search field and at least one song link.
     await expect(page).toHaveURL(/\/songs/);
-    await expect(page.locator('a[href^="/songs/"]').first()).toBeVisible();
+    await expect(page.locator('a[href^="/songs/"]:not([href="/songs/add"])').first()).toBeVisible();
   });
 
   test('VIEW-01: guest can open a song detail page', async ({ page }) => {
     await page.goto('/songs');
-    await page.locator('a[href^="/songs/"]').first().click();
+    await page.locator('a[href^="/songs/"]:not([href="/songs/add"])').first().click();
     await expect(page).toHaveURL(/\/songs\/[^/]+$/);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1825,6 +1826,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -8075,6 +8092,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:smoke": "playwright test --grep @smoke",
     "generate-icons": "node scripts/generate-icons.mjs"
   },
   "dependencies": {
@@ -43,6 +46,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,68 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for Sacred Fire Songs E2E tests.
+ *
+ * Phase 0 foundation (see docs/testing/e2e-test-overview.md).
+ *
+ * Prerequisites to actually run these tests:
+ *   1. A local Supabase stack is running and seeded:  npx supabase start
+ *   2. Env vars are set (see .env.test.example):
+ *        NEXT_PUBLIC_SUPABASE_URL
+ *        NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ *        NEXT_PUBLIC_DEV_TEST_PASSWORD   (the seeded dev password)
+ *
+ * The webServer below builds and starts the app against that stack. We test a
+ * production build (next build && next start) rather than `next dev`, so timing
+ * and bundling match reality.
+ */
+
+const PORT = process.env.PORT ?? '3000';
+const baseURL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  // Per-file parallelism; auth setup runs first via project dependency.
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'never' }], ['list']],
+
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    // 1. Authenticate once per role and persist storageState to e2e/.auth/*.json
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+
+    // 2. Desktop run (depends on setup so storage states exist)
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+    },
+
+    // 3. Mobile run — the app is mobile-first (bottom nav, wake lock)
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+      dependencies: ['setup'],
+    },
+  ],
+
+  // Build + start the app for the duration of the test run.
+  // Reuses an already-running dev/prod server locally for fast iteration.
+  webServer: {
+    command: 'npm run build && npm run start',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});


### PR DESCRIPTION
## Summary

Closes #142. Establishes the end-to-end testing foundation for Sacred Fire Songs: a full E2E coverage matrix, the Playwright scaffolding (Phase 0), and a CI workflow that runs smoke tests against staging Supabase.

This is **planning + foundation only** — it does not attempt to implement the full E2E suite. The smoke specs are authored and discovered (`npx playwright test --list` → 13 tests) but have **not yet run green** (the build env has no browsers/app/Supabase; first real run happens in CI).

## What's included

- **`docs/testing/e2e-test-overview.md`** — living test matrix: ~80 scenarios across 10 feature areas (auth, accounts, song management, library/discovery, viewer, favorites, playlists, gatekeeper, navigation, PWA) with variants, roles (G/M/GK/A), feature status, E2E status, and priority. Includes the Playwright-vs-Cypress decision, CI approach, gap analysis, and phased rollout.
- **Playwright scaffolding (Phase 0):**
  - `playwright.config.ts` — `chromium-desktop` + `mobile-chrome` projects, prod `webServer` (`next build && next start`), trace/screenshot/video on failure.
  - `e2e/auth.setup.ts` + `e2e/fixtures/roles.ts` — per-role `storageState` login via the real `/auth/login` UI, using the seeded admin/musician/member accounts.
  - `e2e/tests/smoke.spec.ts` — 5 P0 `@smoke` happy-path specs (AUTH-04, ACC-01, LIB-01, LIB-07, VIEW-01).
  - `e2e/README.md`, `.env.test.example`, `package.json` scripts (`test:e2e`, `:ui`, `:smoke`), `@playwright/test` dep, `.gitignore` updates.
- **CI** — `.github/workflows/e2e.yml` runs the `@smoke` subset against **staging** Supabase on push to `main`/`feat|fix|chore/**`. URL derived from `SUPABASE_PROJECT_ID_STAGING`; anon key from the `SUPABASE_PUBLISHABLE_KEY_STAGING` secret.

## ⛔ Required before CI passes (repo settings)

1. Add secret **`SUPABASE_PUBLISHABLE_KEY_STAGING`** (staging anon/publishable key).
2. Add secret **`E2E_TEST_PASSWORD`** (seeded-account password, likely `sacred-fire-dev`).
3. **Seed the test accounts on staging** (`roel.de.meester+{admin,musician,member}@gmail.com`) — `deploy-db.yml` pushes migrations but not `supabase/seeds/*.sql`.

## ⚠️ Note for reviewers

CI runs against shared staging on every branch push. The current `@smoke` specs are read-only, but Phase 1+ create/edit/delete specs will mutate staging — test-data isolation/cleanup or an ephemeral DB will be needed before adding destructive tiers.

## Commits

- `555c71a` docs(testing): add E2E test overview/matrix for all features
- `1e57b15` test(e2e): scaffold Phase 0 Playwright foundation
- `001a587` ci(e2e): run @smoke against staging Supabase on push to main/branches
- `0b9791a` ci(e2e): read staging anon key from secret instead of CLI lookup

## Test plan

- [x] `npx playwright test --list` discovers all 13 tests (config + specs parse)
- [ ] CI `@smoke` run green on staging (blocked on secrets + staging seed above)

https://claude.ai/code/session_01PAbkiX6vfoLPC6HANtLQU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAbkiX6vfoLPC6HANtLQU2)_