### PR TITLE
fix: standardize Supabase auth cookie name prefix to fix session mismatch on proxy URL

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -10,5 +10,9 @@ export function createClient() {
     const anonKey = isDev
         ? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY_DEV!
         : process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!;
-    return createBrowserClient(url, anonKey);
+    return createBrowserClient(url, anonKey, {
+        cookieOptions: {
+            name: "sb-auth-token",
+        },
+    });
 }

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -42,6 +42,9 @@ export async function updateSession(request: NextRequest) {
                     );
                 },
             },
+            cookieOptions: {
+                name: "sb-auth-token",
+            },
         },
     );
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -33,6 +33,9 @@ export async function createClient() {
                     }
                 },
             },
+            cookieOptions: {
+                name: "sb-auth-token",
+            },
         },
     );
 }


### PR DESCRIPTION
Overrides the default Supabase cookie name with a static 'sb-auth-token' prefix in client, server, and middleware clients. This resolves the authentication session check failures caused by URL discrepancies between browser (relative path) and server (absolute path).