### PR TITLE
fix(issue-175): resolve duplicate edit/delete buttons on mobile

### DIFF
--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -262,10 +262,10 @@ export default function SongDetailPage() {
                     </div>
                 </div>
 
-                <div className="max-w-5xl p-6 md:p-10 space-y-0">
+                <div className="max-w-5xl px-6 md:px-10 pb-6 md:pb-10 pt-4 md:pt-6 space-y-0">
 
                     {/* Mobile: Song Title, Author, Badges row */}
-                    <div className="lg:hidden flex flex-col gap-4 mb-6">
+                    <div className="lg:hidden flex flex-col gap-4 mb-4">
                         <div className="flex-1 space-y-3">
                             {/* Title and Author Grouping */}
                             <div className="space-y-1">
@@ -306,25 +306,6 @@ export default function SongDetailPage() {
                                     );
                                 })}
                             </div>
-                        </div>
-
-                        {/* Action Buttons (Mobile) */}
-                        <div className="flex items-center gap-2">
-                            {(song.owner_id === user?.id || isAdmin) && (
-                                <button
-                                    onClick={() => setIsDeleteModalOpen(true)}
-                                    className="flex items-center gap-2 px-3 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 rounded-lg text-sm font-bold border border-red-500/20 transition-all"
-                                >
-                                    <Trash2 className="w-4 h-4" /> <span className="sm:inline">Delete</span>
-                                </button>
-                            )}
-                            {(song.owner_id === user?.id || isAdmin) && (
-                                <Link href={`/songs/${id}/edit`}>
-                                    <button className="flex items-center gap-2 px-3 py-2 bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-lg text-sm font-bold border border-gray-300 dark:border-gray-700 transition-all">
-                                        <Edit2 className="w-4 h-4" /> <span className="sm:inline">Edit</span>
-                                    </button>
-                                </Link>
-                            )}
                         </div>
                     </div>
 

--- a/docs/design/application-analysis&design.md
+++ b/docs/design/application-analysis&design.md
@@ -1,6 +1,6 @@
 # Project Analysis & Design Document: Song Sharing Application (Sacred Fire Songs)
 
-**Version:** 1.27
+**Version:** 1.28
 **Status:** Living Document
 **Date:** June 27, 2026
 
@@ -20,6 +20,7 @@
 | **1.25** | Jun 23, 2026 | Added client-side relative Supabase API proxy (/supabase-api) rewrite in client.ts and next.config.ts to prevent Mixed Content protocol blocking on self-hosted environments. |
 | **1.26** | Jun 23, 2026 | Added programmatic random seeder (`random-seeder.mjs`) supporting dynamic generation of rich mock data (visibility, ownership, key/capo, and element/lineage tags) for advanced local and E2E testing, toggleable via `E2E_RANDOM_SEED=1` env variable. |
 | **1.27** | Jun 27, 2026 | Resolved duplicate avatar widget on desktop song detail page. Replaced AccountInfoPanel with UserProfile in Header.tsx, removed duplicate UserProfile from app/songs/[id]/page.tsx, and deleted the obsolete AccountInfoPanel component. |
+| **1.28** | Jun 27, 2026 | Resolved duplicate action buttons on mobile song detail page, removed duplicate Edit/Delete buttons from the main content body, and reduced vertical top/margin whitespace. |
 
 
 ## 1. Introduction

--- a/docs/design/screens/screen2_song_detail.html
+++ b/docs/design/screens/screen2_song_detail.html
@@ -224,10 +224,10 @@
             </div>
         </div>
 
-        <div class="max-w-5xl p-6 md:p-10 space-y-0">
+        <div class="max-w-5xl px-6 md:px-10 pb-6 md:pb-10 pt-4 md:pt-6 space-y-0">
 
             <!-- Mobile: Song Title, Badges, and Action Buttons Row -->
-            <div class="md:hidden flex flex-col gap-4 mb-6">
+            <div class="md:hidden flex flex-col gap-4 mb-4">
                 <div class="flex-1 space-y-3">
                     <!-- Title and Badges -->
                     <div class="flex flex-wrap items-center gap-3">
@@ -256,18 +256,6 @@
 
                 <!-- Action Buttons (Mobile) -->
                 <div class="flex items-center gap-2">
-                    <a href="actions/screen6_delete_confirmation.html">
-                        <button
-                            class="flex items-center gap-2 px-3 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 rounded-lg text-sm font-bold border border-red-500/20 transition-all">
-                            <i data-lucide="trash-2" class="w-4 h-4"></i> <span class="sm:inline">Delete</span>
-                        </button>
-                    </a>
-                    <a href="actions/screen4_song_add.html?mode=edit&id=1">
-                        <button
-                            class="flex items-center gap-2 px-3 py-2 bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg text-sm font-bold border border-gray-700 transition-all">
-                            <i data-lucide="edit-2" class="w-4 h-4"></i> <span class="sm:inline">Edit</span>
-                        </button>
-                    </a>
                     <a href="screen1_home.html" class="p-2 text-gray-400 hover:text-white transition-colors">
                         <i data-lucide="arrow-left" class="w-5 h-5"></i>
                     </a>

--- a/docs/logbook/master-tasks.md
+++ b/docs/logbook/master-tasks.md
@@ -964,3 +964,12 @@
     - [x] Update version history in `application-analysis&design.md`.
     - [x] Validate build and TypeScript type safety locally.
     - [x] Commit, push, and merge branch to main.
+- [x] **Session — Jun 27, 2026 (Duplicate Edit/Delete Actions)**
+    - [x] Create GitHub Issue #175 for duplicate edit/delete buttons bug.
+    - [x] Create branch and worktree `bug/issue-175-duplicate-actions`.
+    - [x] Remove duplicate Edit/Delete buttons from mobile song detail page body.
+    - [x] Reduce vertical whitespace top padding on container and metadata margin.
+    - [x] Align detail page mockup `screen2_song_detail.html`.
+    - [x] Update version history in `application-analysis&design.md`.
+    - [x] Validate build and TypeScript type safety locally.
+    - [x] Commit, push, and merge branch to main.

--- a/docs/logbook/master-timetracking.md
+++ b/docs/logbook/master-timetracking.md
@@ -66,5 +66,6 @@
 | **Jun 23** | **E2E Isolation**: Create setup-test-db.mjs, global-setup.ts, config update, env variable sync | ~1.5 Hours | ✅ Completed |
 | **Jun 23** | **VPS Database Proxy**: Supabase API Proxy rewrite, admin dashboard cards, songbook config rebuild, client absolute URL fix | ~1.0 Hours | ✅ Completed |
 | **Jun 27** | **Bug Fix**: Resolve duplicate avatar widget on desktop song detail view (#173) | ~0.5 Hours | ✅ Completed |
+| **Jun 27** | **Bug Fix**: Resolve duplicate edit/delete buttons on mobile song detail page (#175) | ~0.5 Hours | ✅ Completed |
 
-| **Total** | **Development + AI Collaboration** | **~129.75 Hours** | |
+| **Total** | **Development + AI Collaboration** | **~130.25 Hours** | |

--- a/docs/logbook/master-walkthrough.md
+++ b/docs/logbook/master-walkthrough.md
@@ -2377,3 +2377,25 @@ I have resolved the bug where two user avatar widgets were displayed on the song
 ### 4. Build & Validation
 - Verified that the production build completes successfully (`npm run build`).
 - Ran unit tests (`npm run test`) which all pass successfully.
+
+# Walkthrough - Resolve Duplicate Edit/Delete Buttons (Issue #175) - June 27, 2026
+
+I have resolved the bug where Edit and Delete buttons were duplicated on the mobile song detail page body.
+
+## Actions Taken
+
+### 1. Removed Duplicate Actions on Mobile
+- Removed the duplicate mobile Edit/Delete buttons from the song detail content body in [page.tsx](file:///home/roeland/projects/sacred-fire-songs/app/songs/%5Bid%5D/page.tsx). They are now strictly accessible via the header's context menu.
+
+### 2. Reduced Vertical Whitespace
+- Reduced the main content container's (`max-w-5xl`) top padding from `p-6 md:p-10` to `pt-4 md:pt-6` in [page.tsx](file:///home/roeland/projects/sacred-fire-songs/app/songs/%5Bid%5D/page.tsx).
+- Reduced the mobile title container's margin bottom from `mb-6` to `mb-4`.
+
+### 3. Updated Design & Documentation
+- Removed the duplicate Edit/Delete buttons and reduced top padding in the mockup [screen2_song_detail.html](file:///home/roeland/projects/sacred-fire-songs/docs/design/screens/screen2_song_detail.html) while preserving the back arrow.
+- Updated the changelog in [application-analysis&design.md](file:///home/roeland/projects/sacred-fire-songs/docs/design/application-analysis%26design.md) (v1.28).
+
+### 4. Build & Validation
+- Verified that the production build completes successfully (`npm run build`).
+- Ran unit tests (`npx vitest run lib/unit-tests`) which all pass successfully.
+


### PR DESCRIPTION
This PR resolves #175 by removing the duplicate edit/delete buttons from the mobile page body and optimizing the whitespace between tags and lyrics.