### PR TITLE
feat(issue-179): spotify-style bottom drawer mobile menu and bottom nav auto-hide

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -84,20 +84,20 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         <UserPreferencesProvider>
           <SidebarProvider>
             <QueryProvider>
-              <div className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans selection:bg-red-500/30 overflow-x-hidden">
+              <div className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans selection:bg-red-500/30 overflow-x-clip">
                 {/* Top navigation bar (full width, like Immich) */}
                 <Suspense>
                   <Header />
                 </Suspense>
 
                 {/* Grid: sidebar + main content */}
-                <div className="relative grid grid-cols-[0_1fr] lg:grid-cols-[16rem_1fr] h-[calc(100dvh-var(--navbar-height))] max-md:h-[calc(100dvh-var(--navbar-height))]">
+                <div className="relative grid grid-cols-[0_1fr] lg:grid-cols-[16rem_1fr] lg:h-[calc(100dvh-var(--navbar-height))]">
                   <Sidebar />
 
                   {/* Mobile overlay when sidebar is open */}
                   <SidebarOverlay />
 
-                  <main className="relative overflow-y-auto pb-16 lg:pb-0 col-start-2">
+                  <main className="relative overflow-y-visible lg:overflow-y-auto pb-16 lg:pb-0 col-start-2">
                     {children}
                   </main>
                 </div>

--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, notFound, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
@@ -10,7 +10,8 @@ import SongDetailSkeleton from '@/components/song/SongDetailSkeleton';
 import MediaEmbeds from '@/components/song/MediaEmbeds';
 import DeleteConfirmationModal from '@/components/common/DeleteConfirmationModal';
 import { useQuery } from '@tanstack/react-query';
-import { Trash2, Edit2, ArrowLeft, Music, Link as LinkIcon, Heart, MoreHorizontal } from 'lucide-react';
+import { Trash2, Edit2, Music, Link as LinkIcon, Heart, MoreVertical, ListPlus } from 'lucide-react';
+import { toast } from 'sonner';
 import { useToggleFavorite } from '@/hooks/useToggleFavorite';
 import { PlaylistPicker } from '@/components/playlists/PlaylistPicker';
 import { useDeleteSong } from '@/hooks/useDeleteSong';
@@ -108,6 +109,43 @@ export default function SongDetailPage() {
     });
     const { isFav, handleToggle: handleToggleFavorite } = useToggleFavorite(id!, favoriteIds.has(id!));
 
+    const titleRef = useRef<HTMLSpanElement>(null);
+    const [scrollAmount, setScrollAmount] = useState(0);
+
+    useEffect(() => {
+        if (songLoading || authLoading || !song) return;
+
+        const calculateOverflow = () => {
+            const el = titleRef.current;
+            // Compare span width vs the flex-1 container (grandparent of the overflow wrapper)
+            const container = el?.parentElement?.parentElement;
+            if (el && container) {
+                el.style.transform = 'none';
+                const overflow = el.scrollWidth - container.clientWidth;
+                if (overflow > 0) {
+                    setScrollAmount(overflow);
+                } else {
+                    setScrollAmount(0);
+                }
+                el.style.transform = '';
+            }
+        };
+
+        const timer = setTimeout(calculateOverflow, 100);
+
+        window.addEventListener('resize', calculateOverflow);
+        return () => {
+            clearTimeout(timer);
+            window.removeEventListener('resize', calculateOverflow);
+        };
+    }, [song?.title, songLoading, authLoading]);
+
+    const marqueeStyle = scrollAmount > 0 ? {
+        '--scroll-amount': `-${scrollAmount}px`,
+        animation: 'marquee 8s ease-in-out infinite alternate',
+        textAlign: 'left' as const,
+    } as React.CSSProperties : { textAlign: 'center' as const };
+
     if (songLoading || authLoading) return <SongDetailSkeleton />;
     if (!song) return notFound();
 
@@ -127,62 +165,44 @@ export default function SongDetailPage() {
     return (
         <div className="flex flex-col min-h-screen">
             {/* Mobile Header (Visible only on mobile < lg) */}
-            <header className="lg:hidden flex items-center justify-between px-4 py-3 sticky top-0 bg-gray-100/95 dark:bg-gray-900/95 backdrop-blur-md z-30 border-b border-gray-200 dark:border-white/5 shadow-lg">
-                <Link href="/" className="p-2 -ml-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
-                    <ArrowLeft className="w-5 h-5" />
-                </Link>
-                <h1 className="font-bold text-sm tracking-tight text-gray-900 dark:text-white truncate mx-4 flex-1 text-center">
-                    {song.title}
-                </h1>
-                <div className="flex items-center gap-1">
+            <header style={{ top: 'var(--env-banner-height, 0px)', width: '100vw', maxWidth: '100vw' }} className="lg:hidden flex items-center px-4 py-2 sticky left-0 bg-gray-100/95 dark:bg-gray-900/95 backdrop-blur-md z-30 border-b border-gray-200 dark:border-white/5 shadow-lg min-h-[56px]">
+                {/* Title + Author — flex-1 min-w-0 constrains width */}
+                <div className="flex-1 min-w-0 overflow-hidden py-0.5 mx-4">
+                    {/* overflow-hidden clips; span is block so it fills the constrained width */}
+                    <div className="overflow-hidden">
+                        <span
+                            ref={titleRef}
+                            style={marqueeStyle}
+                            className="font-black text-2xl text-[#ff4400] tracking-tight whitespace-nowrap block w-full"
+                        >
+                            {song.title}
+                        </span>
+                    </div>
+                    {/* Author */}
+                    <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                        by {song.original_author || 'Traditional'}
+                    </div>
+                </div>
+                {/* 3-dot menu — flex-none so it never shrinks */}
+                <div className="flex-none flex items-center">
                     <button
-                        onClick={handleToggleFavorite}
-                        aria-label={isFav ? 'Remove from favorites' : 'Add to favorites'}
-                        className={`p-2 rounded-full transition-all duration-300 ${isFav ? 'text-amber-400' : 'text-gray-500 hover:text-amber-400/60'}`}
+                        onClick={() => setIsOverflowOpen(!isOverflowOpen)}
+                        className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+                        aria-label="More actions"
                     >
-                        <Heart className={`w-5 h-5 transition-all duration-200 ${isFav ? 'fill-amber-400' : ''}`} strokeWidth={1.5} />
+                        <MoreVertical className="w-5 h-5" />
                     </button>
-                    {user && (
-                        <div className="relative">
-                            <button
-                                onClick={() => setIsOverflowOpen(!isOverflowOpen)}
-                                className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
-                                aria-label="More actions"
-                            >
-                                <MoreHorizontal className="w-5 h-5" />
-                            </button>
-                            {isOverflowOpen && (
-                                <>
-                                    <div className="fixed inset-0 z-40" onClick={() => setIsOverflowOpen(false)} />
-                                    <div className="absolute right-0 top-full mt-1 z-50 bg-gray-100 dark:bg-gray-900 border border-gray-300/50 dark:border-gray-700/50 rounded-xl overflow-hidden shadow-2xl shadow-black/50 min-w-[180px]">
-                                        {(song.owner_id === user?.id || isAdmin) && (
-                                            <Link
-                                                href={`/songs/${id}/edit`}
-                                                onClick={() => setIsOverflowOpen(false)}
-                                                className="flex items-center gap-3 px-4 py-3 hover:bg-gray-200/50 dark:hover:bg-gray-800/50 transition-colors text-gray-700 dark:text-gray-300"
-                                            >
-                                                <Edit2 className="w-4 h-4" />
-                                                <span className="text-sm font-medium">Edit</span>
-                                            </Link>
-                                        )}
-                                        {(song.owner_id === user?.id || isAdmin) && (
-                                            <button
-                                                onClick={() => { setIsOverflowOpen(false); setIsDeleteModalOpen(true); }}
-                                                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-red-500/10 transition-colors text-red-400"
-                                            >
-                                                <Trash2 className="w-4 h-4" />
-                                                <span className="text-sm font-medium">Delete</span>
-                                            </button>
-                                        )}
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                    )}
                 </div>
             </header>
 
-            <main className="flex-1 min-w-0 overflow-y-auto bg-white dark:bg-gray-950">
+            <style dangerouslySetInnerHTML={{ __html: `
+                @keyframes marquee {
+                    0%, 15% { transform: translateX(0); }
+                    85%, 100% { transform: translateX(var(--scroll-amount)); }
+                }
+            `}} />
+
+            <main className="flex-1 min-w-0 lg:overflow-y-auto overflow-y-visible bg-white dark:bg-gray-950">
 
                 {/* Desktop Page Header (Title, Actions) - Visible only on desktop >= lg */}
                 <div className="hidden lg:flex justify-between items-center px-8 py-4 border-b border-gray-200/50 dark:border-gray-800/50 bg-white/50 dark:bg-gray-950/50 sticky top-0 backdrop-blur-md z-10 transition-all">
@@ -255,9 +275,6 @@ export default function SongDetailPage() {
                         >
                             <Heart className={`w-5 h-5 transition-all duration-200 ${isFav ? 'fill-amber-400' : ''}`} strokeWidth={1.5} />
                         </button>
-                        <Link href="/" className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
-                            <ArrowLeft className="w-5 h-5" />
-                        </Link>
 
                     </div>
                 </div>
@@ -265,19 +282,8 @@ export default function SongDetailPage() {
                 <div className="max-w-5xl px-6 md:px-10 pb-6 md:pb-10 pt-4 md:pt-6 space-y-0">
 
                     {/* Mobile: Song Title, Author, Badges row */}
-                    <div className="lg:hidden flex flex-col gap-4 mb-4">
+                     <div className="lg:hidden flex flex-col gap-4 mb-4">
                         <div className="flex-1 space-y-3">
-                            {/* Title and Author Grouping */}
-                            <div className="space-y-1">
-                                <div className="flex flex-wrap items-baseline gap-x-3">
-                                    <h1 className="text-4xl font-black text-[#ff4400] tracking-tight">{song.title}</h1>
-                                    <p className="text-gray-500 dark:text-gray-400 text-base font-medium">by{' '}
-                                        <Link href={`/songs?artist=${encodeURIComponent(song.original_author || 'Traditional')}`} className="hover:text-gray-900 dark:hover:text-white hover:underline transition-colors">
-                                            {song.original_author || 'Traditional'}
-                                        </Link>
-                                    </p>
-                                </div>
-                            </div>
 
                             {/* Technical Badges (Chords/Melody) */}
                             <div className="flex items-center gap-2">
@@ -362,6 +368,102 @@ export default function SongDetailPage() {
                     isDeleting={isDeleting}
                 />
             </main>
+
+            {/* Mobile Bottom Drawer Context Menu */}
+            {isOverflowOpen && (
+                <>
+                    {/* Backdrop overlay */}
+                    <div 
+                        className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40 lg:hidden animate-in fade-in duration-200" 
+                        onClick={() => setIsOverflowOpen(false)} 
+                    />
+                    {/* Bottom sheet */}
+                    <div 
+                        className="fixed bottom-0 inset-x-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 rounded-t-3xl shadow-2xl z-50 pb-safe-bottom lg:hidden animate-in slide-in-from-bottom duration-300 flex flex-col"
+                    >
+                        {/* Handle bar */}
+                        <div className="w-12 h-1.5 bg-gray-300 dark:bg-gray-700 rounded-full mx-auto my-3 shrink-0" />
+                        
+                        {/* Song Info header inside sheet */}
+                        <div className="flex items-center gap-4 px-6 py-4 border-b border-gray-100 dark:border-gray-800/50">
+                            <div className="w-12 h-12 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl flex items-center justify-center text-white shrink-0 shadow-lg shadow-purple-500/10">
+                                <Music className="w-6 h-6" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <h2 className="text-base font-black text-gray-900 dark:text-white truncate text-left">{song.title}</h2>
+                                <p className="text-xs text-gray-500 dark:text-gray-400 truncate text-left">by {song.original_author || 'Traditional'}</p>
+                            </div>
+                        </div>
+
+                        {/* Action options */}
+                        <div className="py-2">
+                            {/* Like / Favorite */}
+                            <button
+                                onClick={() => { handleToggleFavorite(); setIsOverflowOpen(false); }}
+                                className="w-full flex items-center gap-4 px-6 py-4 hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-colors text-left text-gray-700 dark:text-gray-300"
+                            >
+                                <Heart className={`w-5 h-5 ${isFav ? 'text-amber-500 fill-amber-500' : 'text-gray-400 dark:text-gray-500'}`} />
+                                <span className="text-sm font-bold">{isFav ? 'Remove from Liked Songs' : 'Add to Liked Songs'}</span>
+                            </button>
+
+                            {/* Add to Playlist */}
+                            {user ? (
+                                id && (
+                                    <PlaylistPicker
+                                        compositionId={id as string}
+                                        userId={user.id}
+                                        label="Add to Playlist"
+                                        triggerClassName="w-full flex items-center gap-4 px-6 py-4 hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-colors text-left rounded-none text-gray-700 dark:text-gray-300"
+                                        iconClassName="w-5 h-5"
+                                    />
+                                )
+                            ) : (
+                                <button
+                                    onClick={() => {
+                                        setIsOverflowOpen(false);
+                                        toast('Sign in to manage playlists', {
+                                            action: {
+                                                label: 'Sign in →',
+                                                onClick: () => { window.location.href = `/auth/login?next=${encodeURIComponent(window.location.pathname)}`; },
+                                            },
+                                            classNames: {
+                                                actionButton: 'text-amber-400 text-xs font-bold hover:text-amber-300 transition-colors ml-2',
+                                            },
+                                        });
+                                    }}
+                                    className="w-full flex items-center gap-4 px-6 py-4 hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-colors text-left text-gray-700 dark:text-gray-300"
+                                >
+                                    <ListPlus className="w-5 h-5 text-gray-400 dark:text-gray-500" />
+                                    <span className="text-sm font-bold">Add to Playlist</span>
+                                </button>
+                            )}
+
+                            {/* Edit */}
+                            {(song.owner_id === user?.id || isAdmin) && (
+                                <Link
+                                    href={`/songs/${id}/edit`}
+                                    onClick={() => setIsOverflowOpen(false)}
+                                    className="flex items-center gap-4 px-6 py-4 hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-colors text-gray-700 dark:text-gray-300"
+                                >
+                                    <Edit2 className="w-5 h-5 text-gray-400 dark:text-gray-500" />
+                                    <span className="text-sm font-bold">Edit Song</span>
+                                </Link>
+                            )}
+
+                            {/* Delete */}
+                            {(song.owner_id === user?.id || isAdmin) && (
+                                <button
+                                    onClick={() => { setIsOverflowOpen(false); setIsDeleteModalOpen(true); }}
+                                    className="w-full flex items-center gap-4 px-6 py-4 hover:bg-red-500/10 transition-colors text-red-500 text-left"
+                                >
+                                    <Trash2 className="w-5 h-5" />
+                                    <span className="text-sm font-bold">Delete Song</span>
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                </>
+            )}
         </div>
     );
 }

--- a/components/account/settings/PreferencesSettings.tsx
+++ b/components/account/settings/PreferencesSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Monitor, FileText, Music2, Type, WifiOff, Sun, Moon } from "lucide-react";
+import { Monitor, FileText, Music2, Type, WifiOff, Sun, Moon, SlidersHorizontal } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import { useUserPreferences, type ThemePreference } from "@/context/UserPreferencesContext";
@@ -113,6 +113,15 @@ export default function PreferencesSettings() {
         onCheckedChange={(v) => setPreference("keepScreenAwake", v)}
         disabled={!isSupported}
         notSupported={!isSupported}
+      />
+
+      {/* Auto-hide Bottom Nav — functional */}
+      <PreferenceRow
+        icon={<SlidersHorizontal className="w-5 h-5" />}
+        label="Auto-hide navigation bar"
+        description="Hide bottom navigation bar on song detail pages after a few seconds of inactivity."
+        checked={preferences.autoHideBottomNav}
+        onCheckedChange={(v) => setPreference("autoHideBottomNav", v)}
       />
 
       {/* Auto-scroll Lyrics — disabled */}

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -143,7 +143,7 @@ export default function Header() {
     return (
         <nav
             id="app-navbar"
-            className="h-[var(--navbar-height)] w-full text-sm sticky top-0 z-50 bg-white/95 dark:bg-gray-950/95 backdrop-blur-md"
+            className="h-[var(--navbar-height)] w-full text-sm relative lg:sticky lg:top-0 z-50 bg-white/95 dark:bg-gray-950/95 backdrop-blur-md"
         >
             <div className="grid h-full grid-cols-[1fr_auto] sm:grid-cols-[auto_1fr_auto] lg:grid-cols-[16rem_1fr_auto] items-center border-b border-gray-200/60 dark:border-gray-800/60">
                 {/* Left: Menu button + Logo */}

--- a/components/common/MobileBottomNav.tsx
+++ b/components/common/MobileBottomNav.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { Home, Library, ListMusic, PlusCircle } from 'lucide-react';
 import { useActivePath } from '@/hooks/useActivePath';
 import { usePathname } from 'next/navigation';
 import type { LucideIcon } from 'lucide-react';
 import CreateSheet from './CreateSheet';
+import { useUserPreferences } from '@/context/UserPreferencesContext';
 
 type TabItem = {
     label: string;
@@ -28,14 +29,49 @@ export default function MobileBottomNav() {
     const { isActive } = useActivePath();
     const pathname = usePathname();
     const [isSheetOpen, setIsSheetOpen] = useState(false);
+    const { preferences } = useUserPreferences();
+    const [isVisible, setIsVisible] = useState(true);
+    const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-    // Hide on song detail pages (they have custom layouts)
     const isSongDetailPage = pathname?.startsWith('/songs/') &&
         pathname !== '/songs' &&
         pathname !== '/songs/add' &&
         !pathname.endsWith('/edit');
 
-    if (isSongDetailPage) return null;
+    useEffect(() => {
+        if (!isSongDetailPage || !preferences.autoHideBottomNav) {
+            setIsVisible(true);
+            return;
+        }
+
+        const showNav = () => {
+            setIsVisible(true);
+            
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+            
+            timeoutRef.current = setTimeout(() => {
+                setIsVisible(false);
+            }, 3000);
+        };
+
+        showNav();
+
+        const events = ['scroll', 'click', 'touchstart', 'touchmove', 'mousemove', 'keydown'];
+        events.forEach(event => {
+            window.addEventListener(event, showNav, { passive: true });
+        });
+
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+            events.forEach(event => {
+                window.removeEventListener(event, showNav);
+            });
+        };
+    }, [isSongDetailPage, preferences.autoHideBottomNav]);
 
     return (
         <>
@@ -43,7 +79,7 @@ export default function MobileBottomNav() {
                 isOpen={isSheetOpen}
                 onClose={() => setIsSheetOpen(false)}
             />
-            <nav className="fixed bottom-0 inset-x-0 z-30 lg:hidden">
+            <nav className={`fixed bottom-0 inset-x-0 z-30 lg:hidden transition-transform duration-300 ${!isVisible ? 'translate-y-full' : 'translate-y-0'}`}>
                 {/* Top edge glow */}
                 <div className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-red-500/30 to-transparent" />
 

--- a/components/playlists/PlaylistPicker.tsx
+++ b/components/playlists/PlaylistPicker.tsx
@@ -18,6 +18,7 @@ interface PlaylistPickerProps {
     triggerClassName?: string;
     /** className for the ListPlus icon — defaults to w-3.5 h-3.5 */
     iconClassName?: string;
+    label?: string;
 }
 
 // ─── Data fetching ────────────────────────────────────────────────────────────
@@ -44,7 +45,7 @@ async function fetchContainingPlaylists(compositionId: string) {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function PlaylistPicker({ compositionId, userId, triggerClassName, iconClassName }: PlaylistPickerProps) {
+export function PlaylistPicker({ compositionId, userId, triggerClassName, iconClassName, label }: PlaylistPickerProps) {
     const [open, setOpen] = useState(false);
     const [newTitle, setNewTitle] = useState('');
     const [isCreating, startCreateTransition] = useTransition();
@@ -130,7 +131,14 @@ export function PlaylistPicker({ compositionId, userId, triggerClassName, iconCl
                         triggerClassName
                     )}
                 >
-                    <ListPlus className={iconClassName ?? 'w-3.5 h-3.5'} />
+                    {label ? (
+                        <div className="flex items-center gap-4 w-full">
+                            <ListPlus className={iconClassName ?? 'w-3.5 h-3.5'} />
+                            <span className="text-sm font-bold">{label}</span>
+                        </div>
+                    ) : (
+                        <ListPlus className={iconClassName ?? 'w-3.5 h-3.5'} />
+                    )}
                 </button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-64">

--- a/context/UserPreferencesContext.tsx
+++ b/context/UserPreferencesContext.tsx
@@ -7,6 +7,7 @@ export type ThemePreference = 'dark' | 'light' | 'system';
 interface UserPreferences {
   keepScreenAwake: boolean;
   theme: ThemePreference;
+  autoHideBottomNav: boolean;
 }
 
 interface UserPreferencesContextType {
@@ -20,6 +21,7 @@ const STORAGE_KEY = 'sacred-fire-songs-preferences';
 const defaultPreferences: UserPreferences = {
   keepScreenAwake: true, // Enabled by default as requested for mobile convenience
   theme: 'dark', // Backward compatible — existing users stay on dark
+  autoHideBottomNav: true,
 };
 
 const UserPreferencesContext = createContext<UserPreferencesContextType | undefined>(undefined);

--- a/docs/design/application-analysis&design.md
+++ b/docs/design/application-analysis&design.md
@@ -1,6 +1,6 @@
 # Project Analysis & Design Document: Song Sharing Application (Sacred Fire Songs)
 
-**Version:** 1.28
+**Version:** 1.29
 **Status:** Living Document
 **Date:** June 27, 2026
 
@@ -21,6 +21,7 @@
 | **1.26** | Jun 23, 2026 | Added programmatic random seeder (`random-seeder.mjs`) supporting dynamic generation of rich mock data (visibility, ownership, key/capo, and element/lineage tags) for advanced local and E2E testing, toggleable via `E2E_RANDOM_SEED=1` env variable. |
 | **1.27** | Jun 27, 2026 | Resolved duplicate avatar widget on desktop song detail page. Replaced AccountInfoPanel with UserProfile in Header.tsx, removed duplicate UserProfile from app/songs/[id]/page.tsx, and deleted the obsolete AccountInfoPanel component. |
 | **1.28** | Jun 27, 2026 | Resolved duplicate action buttons on mobile song detail page, removed duplicate Edit/Delete buttons from the main content body, and reduced vertical top/margin whitespace. |
+| **1.29** | Jun 27, 2026 | Implemented mobile song detail page Spotify-style slide-up bottom sheet context menu, moved Like button inside drawer, removed Back button, enabled bottom nav on details page, and added auto-hide bottom nav preference toggle. |
 
 
 ## 1. Introduction

--- a/docs/logbook/master-tasks.md
+++ b/docs/logbook/master-tasks.md
@@ -982,3 +982,14 @@
     - [x] Update version history in `application-analysis&design.md`.
     - [x] Validate build and TypeScript type safety locally.
     - [x] Commit, push, and merge branch to main.
+- [x] **Session — Jun 27, 2026 (Spotify-style Bottom Drawer Context Menu and Bottom Nav Auto-Hide)**
+    - [x] Create GitHub Issue #179.
+    - [x] Create branch and worktree `feat/issue-179-spotify-menu`.
+    - [x] Implement mobile slide-up bottom drawer context menu in `page.tsx`.
+    - [x] Remove mobile back button and heart button from header in `page.tsx`.
+    - [x] Update `PlaylistPicker` to support text labels and add it to bottom drawer.
+    - [x] Add `autoHideBottomNav` preference and setting toggle.
+    - [x] Implement bottom nav auto-hide and user interaction scroll/touch reveal in `MobileBottomNav.tsx`.
+    - [x] Update version history in `application-analysis&design.md`.
+    - [x] Validate build and TypeScript type safety locally.
+    - [x] Commit, push, and merge branch to main.

--- a/docs/logbook/master-timetracking.md
+++ b/docs/logbook/master-timetracking.md
@@ -68,5 +68,6 @@
 | **Jun 27** | **Bug Fix**: Resolve duplicate avatar widget on desktop song detail view (#173) | ~0.5 Hours | ✅ Completed |
 | **Jun 27** | **Bug Fix**: Resolve duplicate edit/delete buttons on mobile song detail page (#175) | ~0.5 Hours | ✅ Completed |
 | **Jun 27** | **UX Polish**: Remove Flame logo and global ThemeToggle, and sync dropdown avatar background (#177) | ~0.5 Hours | ✅ Completed |
+| **Jun 27** | **Feature**: Spotify-style bottom drawer, mobile header cleanup, bottom nav detail page display & settings-controlled auto-hide (#179) | ~1.0 Hours | ✅ Completed |
 
-| **Total** | **Development + AI Collaboration** | **~130.75 Hours** | |
+| **Total** | **Development + AI Collaboration** | **~131.75 Hours** | |

--- a/docs/logbook/master-walkthrough.md
+++ b/docs/logbook/master-walkthrough.md
@@ -2420,4 +2420,37 @@ I have completed the header and avatar visual polish to improve layout consisten
 - Verified that the production build completes successfully (`npm run build`).
 - Ran unit tests (`npx vitest run lib/unit-tests`) which all pass successfully.
 
+# Walkthrough - Spotify-style Mobile Drawer and Bottom Nav Auto-Hide (Issue #179) - June 27, 2026
+
+I have implemented the slide-up bottom drawer context menu on mobile and added the bottom navigation auto-hide setting and logic.
+
+## Actions Taken
+
+### 1. Spotify-style Bottom Drawer Context Menu
+- Replaced the mobile actions trigger in [page.tsx](file:///home/roeland/projects/sacred-fire-songs/app/songs/%5Bid%5D/page.tsx) with the vertical ellipsis icon (`MoreVertical`).
+- Replaced the mobile dropdown menu with a slide-up, full-width bottom sheet context menu containing:
+  - Header showing the song title and artist with a music logo.
+  - Heart toggle ("Add to Liked Songs" / "Remove from Liked Songs").
+  - Add to Playlist (re-used the existing `PlaylistPicker`).
+  - Edit Song (if owner/admin).
+  - Delete Song (if owner/admin).
+- Updated [PlaylistPicker.tsx](file:///home/roeland/projects/sacred-fire-songs/components/playlists/PlaylistPicker.tsx) to support an optional `label` prop, enabling us to render a text description next to the list plus icon in the bottom sheet.
+
+### 2. Mobile Header Pruning
+- Removed the back button and the heart button from the mobile sticky header in [page.tsx](file:///home/roeland/projects/sacred-fire-songs/app/songs/%5Bid%5D/page.tsx).
+
+### 3. Bottom Nav Auto-Hide Configuration
+- Exposed a new preference `autoHideBottomNav` (boolean, default `true`) in [UserPreferencesContext.tsx](file:///home/roeland/projects/sacred-fire-songs/context/UserPreferencesContext.tsx).
+- Added a toggle under [PreferencesSettings.tsx](file:///home/roeland/projects/sacred-fire-songs/components/account/settings/PreferencesSettings.tsx) (labeled "Auto-hide navigation bar") to control this preference.
+- Updated [MobileBottomNav.tsx](file:///home/roeland/projects/sacred-fire-songs/components/common/MobileBottomNav.tsx) to allow bottom navigation on song detail pages.
+- Implemented a 3-second auto-hide timer in [MobileBottomNav.tsx](file:///home/roeland/projects/sacred-fire-songs/components/common/MobileBottomNav.tsx) using user interactions (scroll, touch, click, mousemove, keydown) to reveal the navigation bar and reset the timer.
+
+### 4. Design & Documentation
+- Documented version `1.29` in the changelog of [application-analysis&design.md](file:///home/roeland/projects/sacred-fire-songs/docs/design/application-analysis%26design.md).
+
+### 5. Build & Validation
+- Verified that the production build completes successfully (`npm run build`).
+- Ran unit tests (`npx vitest run lib/unit-tests`) which all pass successfully.
+
+
 

--- a/hooks/useToggleFavorite.ts
+++ b/hooks/useToggleFavorite.ts
@@ -43,6 +43,11 @@ export function useToggleFavorite(id: string, initialIsFavorite: boolean = false
                 });
             }
         } else {
+            if (result.isFavorite) {
+                toast.success('Added to Liked Songs');
+            } else {
+                toast.success('Removed from Liked Songs');
+            }
             // Invalidate the shared favorites cache so every consumer sees fresh data
             queryClient.invalidateQueries({ queryKey: SONG_KEYS.allFavorites() });
         }


### PR DESCRIPTION
This PR resolves #179 by implementing a Spotify-style slide-up bottom drawer context menu, moving the mobile heart button inside it, removing the mobile back button from the header, and adding settings-controlled bottom nav auto-hide logic.