### PR TITLE
fix(ui): remove duplicate mobile header on song edit page (#189)

### DIFF
--- a/app/songs/[id]/edit/page.tsx
+++ b/app/songs/[id]/edit/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useParams, notFound } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import { useSidebar } from '@/context/SidebarContext';
-import { Flame, IndentIncrease } from 'lucide-react';
+
 import SongForm from '@/components/song/SongForm';
 import AccessDenied from '@/components/common/feedback/AccessDenied';
 import { useQuery } from '@tanstack/react-query';
@@ -46,7 +45,7 @@ export default function EditSongPage() {
     const params = useParams();
     const id = typeof params.id === 'string' ? params.id : params.id?.[0];
     const { user, loading: authLoading } = useAuth();
-    const { setIsOpen } = useSidebar();
+
 
     const { data: song, isLoading, error } = useQuery({
         queryKey: ['song', id, 'edit'],
@@ -97,22 +96,6 @@ export default function EditSongPage() {
 
     return (
         <div className="min-h-screen bg-white dark:bg-gray-950 pb-20">
-            {/* Mobile Header (Standardized) */}
-            <header className="lg:hidden flex justify-between items-center px-4 py-3 sticky top-0 bg-gray-100/95 dark:bg-gray-900/95 backdrop-blur-md z-30 border-b border-gray-200 dark:border-white/5 shadow-lg">
-                <div className="flex items-center gap-3">
-                    <button
-                        onClick={() => setIsOpen(true)}
-                        className="flex items-center gap-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors p-1.5 pr-3 rounded-xl hover:bg-gray-200 dark:hover:bg-gray-800 group shrink-0 border border-transparent hover:border-gray-300 dark:hover:border-gray-700"
-                    >
-                        <IndentIncrease className="w-7 h-7" />
-                        <span className="text-[10px] font-bold uppercase tracking-widest opacity-60 group-hover:opacity-100 transition-opacity hidden sm:inline">Menu</span>
-                    </button>
-
-                    <div className="w-8 h-8 bg-gradient-to-br from-red-700 to-orange-600 rounded-full flex items-center justify-center shadow-lg shadow-red-900/30 ring-1 ring-gray-900/10 dark:ring-white/10 shrink-0">
-                        <Flame className="text-white w-5 h-5 fill-current" />
-                    </div>
-                </div>
-            </header>
 
             <main className="container mx-auto px-4 pt-4 lg:pt-8">
 


### PR DESCRIPTION
## Description

Fixes #189 — the song edit page rendered its own mobile header with a hamburger menu on top of the global header (from layout.tsx), causing two stacked header bars on mobile.

## Changes

- Removed the custom mobile header block from `app/songs/[id]/edit/page.tsx`
- Cleaned up unused imports (`Flame`, `IndentIncrease`, `useSidebar`)

## Verification

- [x] TypeScript: no new errors
- [x] ESLint: passes cleanly
- [x] Mobile: only one header bar visible on edit page