### PR TITLE
fix: deduplicate artist names with diacritics in artist aggregation (#164)

### DIFF
--- a/lib/songs/serverQueries.ts
+++ b/lib/songs/serverQueries.ts
@@ -3,7 +3,7 @@ import type { Song } from "@/lib/songUtils";
 import type { TaxonomyNode } from "@/lib/taxonomyUtils";
 import { songsQuery, mapCompositionToSong } from './queries';
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { normalizeWhitespace } from "@/lib/utils";
+import { normalizeWhitespace, removeDiacritics } from "@/lib/utils";
 
 const PAGE_SIZE = 20;
 
@@ -437,7 +437,7 @@ export async function fetchArtistsServer(): Promise<ArtistSummary[]> {
         const normalized = normalizeWhitespace(originalName);
         if (!normalized) continue;
 
-        const key = normalized.toLowerCase();
+        const key = removeDiacritics(normalized).toLowerCase();
 
         authorCounts.set(key, (authorCounts.get(key) || 0) + 1);
 


### PR DESCRIPTION
## Description

Fixes #164 — artist names with diacritics (e.g. 'José' vs 'Jose') now deduplicate correctly in the artist aggregation on `/library/artists`.

## Changes

- `lib/songs/serverQueries.ts:440` — Added `removeDiacritics()` to the dedup key so accented and unaccented variants of the same name are grouped as one artist entry.

## Verification

- [x] Unit tests pass (7/7 artist normalization tests)
- [x] TypeScript: no new errors