### PR TITLE
feat(song-detail): show Add to Playlist button for guests on desktop

### DIFF
--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -396,6 +396,25 @@ export default function SongDetailPage() {
                                 iconClassName="w-[17px] h-[17px]"
                             />
                         )}
+                        {!user && (
+                            <button
+                                onClick={() => {
+                                    toast('Sign in to manage playlists', {
+                                        action: {
+                                            label: 'Sign in →',
+                                            onClick: () => { window.location.href = `/auth/login?next=${encodeURIComponent(window.location.pathname)}`; },
+                                        },
+                                        classNames: {
+                                            actionButton: 'text-amber-400 text-xs font-bold hover:text-amber-300 transition-colors ml-2',
+                                        },
+                                    });
+                                }}
+                                aria-label="Add to playlist"
+                                className="p-2 rounded-full transition-all duration-300 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                            >
+                                <ListPlus className="w-5 h-5" strokeWidth={1.5} />
+                            </button>
+                        )}
                         <button
                             onClick={handleToggleFavorite}
                             aria-label={isFav ? 'Remove from favorites' : 'Add to favorites'}


### PR DESCRIPTION
## Changes

- Add 'Add to Playlist' button visible for guests on desktop
- Shows sign-in prompt button when not logged in (consistent with mobile behavior)

## Acceptance Criteria

- [x] Guests see the Add to Playlist button on desktop song detail page
- [x] Clicking the button shows a toast with sign-in option
- [x] Logged-in users see the full PlaylistPicker component