### PR TITLE
feat: add Guaraní and Camino Rojo categories to database and update seed and setup scripts

### DIFF
--- a/.brain/task.md
+++ b/.brain/task.md
@@ -1,5 +1,6 @@
-# Task: Media Player UX & E2E Test Lint Fixes
+# Task: Add Guaraní and Camino Rojo categories
 
-- [x] Fix TypeScript and ESLint type warnings in `e2e/tests/recording.spec.ts` (untyped page parameters and window assertions).
-- [x] Correct `@typescript-eslint/ban-ts-comment` error by adding explanation to `@ts-expect-error` comment.
-- [x] Align submodule references and push to remote to trigger Vercel build.
+- [x] Insert the Guaraní subcategory under the Languages category directly in production database
+- [x] Insert the Camino Rojo subcategory under the Lineage & Tradition category directly in production database
+- [x] Update database schema setup file `docs/design/db-schema.sql` to include the categories and bump version to v2.7
+- [x] Update existing seed/script files (`scripts/random-seeder.mjs` and legacy SQL) with the new categories

--- a/.brain/time_tracking_report.md
+++ b/.brain/time_tracking_report.md
@@ -1,1 +1,1 @@
-| **2026-07-14 (Part 3)** | **E2E & Submodule Polish**: Resolve lint/typing issues in E2E tests, update parent submodule reference, and run synchronization workflows | ~0.75 Hours | ✅ Completed |
+| **2026-07-15** | **Database tags update**: Add Guaraní and Camino Rojo categories to production database and update setup/seed files | ~0.5 Hours | ✅ Completed |

--- a/.brain/walkthrough.md
+++ b/.brain/walkthrough.md
@@ -1,9 +1,6 @@
-## 2026-07-14 (Media Player UX & E2E Test Lint Fixes)
+## 2026-07-15 (Add Guaraní and Camino Rojo categories)
 
-### 1. Rehearsal Recording E2E Test Fixes
-- Resolved untyped `page: any` parameter warning by importing and using the `Page` type from `@playwright/test` in [recording.spec.ts](file:///home/roeland/projects/sacred-fire-songs/e2e/tests/recording.spec.ts).
-- Fixed `Unexpected any` error on `window` object by casting it to `unknown as { __E2E_FAST_TIMER__: boolean }`.
-- Replaced `// @ts-ignore` with `// @ts-expect-error - overriding window.Blob for testing` to satisfy ESLint documentation requirements.
-
-### 2. Parent Repository Sync
-- Pinned the `engine` submodule in `songbook-rocks` to the latest commit and pushed to `feat/issue-187-media-player-ux` to trigger the Vercel preview deployment.
+### 1. Database Seed Updates
+- Directly updated the production and staging databases to insert "Guaraní" (Languages category) and "Camino Rojo" (Lineage & Tradition category) subcategories.
+- Updated the consolidated database schema setup [db-schema.sql](file:///home/roeland/projects/sacred-fire-songs/docs/design/db-schema.sql) to include the new categories in the master seed block and bumped the file version to `2.7`.
+- Updated the programmatic database seeder [random-seeder.mjs](file:///home/roeland/projects/sacred-fire-songs/scripts/random-seeder.mjs) and legacy category script [categories.sql](file:///home/roeland/projects/sacred-fire-songs/data/scripts/legacy/categories.sql) to include the new category insertions.

--- a/data/scripts/legacy/categories.sql
+++ b/data/scripts/legacy/categories.sql
@@ -68,6 +68,7 @@ values
 ('Portuguese', 'portuguese', '🇧🇷', 'Hinos and songs from the Brazilian traditions.', (select id from groups where name = 'Languages')),
 ('Nahuatl', 'nahuatl', '🏹', 'Ancient songs from the Mexica and Mesoamerican traditions.', (select id from groups where name = 'Languages')),
 ('Huni Kuin', 'huni-kuin', '🐍', 'Sacred chants in the Hatxa Kuin language.', (select id from groups where name = 'Languages')),
+('Guaraní', 'guarani', '🏹', null, (select id from groups where name = 'Languages')),
 
 -- LINEAGE & TRADITION
 ('Andean', 'andean', '🧣', 'Songs from the high mountains and Q''ero traditions.', (select id from groups where name = 'Lineage & Tradition')),
@@ -75,6 +76,7 @@ values
 ('Native American', 'native-american', '🪶', 'Songs from Northern traditions and the Red Road.', (select id from groups where name = 'Lineage & Tradition')),
 ('Santo Daime / Umbanda', 'santo-daime-umbanda', '🌟', 'Specific religious spiritual lineages from Brazil.', (select id from groups where name = 'Lineage & Tradition')),
 ('Traditional', 'traditional', '📜', 'Folk songs passed down through oral tradition.', (select id from groups where name = 'Lineage & Tradition')),
+('Camino Rojo', 'camino-rojo', '🔴', null, (select id from groups where name = 'Lineage & Tradition')),
 
 -- MEDICINE & HEALING
 ('Medicine Songs', 'medicine-songs', '🧪', 'The broad category for songs used in ceremony.', (select id from groups where name = 'Medicine & Healing')),

--- a/docs/design/db-schema.sql
+++ b/docs/design/db-schema.sql
@@ -1,11 +1,12 @@
 /*
- **Version:** 2.6
+ **Version:** 2.7
  **Status:** Current
- **Date:** February 27, 2026
+ **Date:** July 15, 2026
  
  ## Usage
  This script provides a complete setup for the "Sacred Fire Songs" database. 
- It consolidates the initial schema and all subsequent migrations up to Feb 27, 2026.
+ It consolidates the initial schema and all subsequent migrations up to July 15, 2026.
+ (v2.7: Added Guaraní and Camino Rojo categories).
  (v2.6: Added partial indexes for is_public and alphabetical title index).
  (v2.4: Added tuning to song_versions).
  Run this in the Supabase SQL Editor to initialize a fresh database.
@@ -586,6 +587,17 @@ values -- THE ELEMENTS
       where name = 'Languages'
     )
   ),
+  (
+    'Guaraní',
+    'guarani',
+    '🏹',
+    null,
+    (
+      select id
+      from groups
+      where name = 'Languages'
+    )
+  ),
   -- LINEAGE & TRADITION
   (
     'Andean',
@@ -679,6 +691,17 @@ values -- THE ELEMENTS
     'Umbanda',
     'umbanda',
     '🌊',
+    null,
+    (
+      select id
+      from groups
+      where name = 'Lineage & Tradition'
+    )
+  ),
+  (
+    'Camino Rojo',
+    'camino-rojo',
+    '🔴',
     null,
     (
       select id

--- a/docs/logbook/master-tasks.md
+++ b/docs/logbook/master-tasks.md
@@ -1081,3 +1081,10 @@
 - [x] Refactor `CardContent` subtitle container to use simple block-level `truncate` for reliable responsive sizing
 - [x] Add layout constraints (`min-w-0`) to `app/layout.tsx` main grid content and `app/library/layout.tsx` container
 - [x] Validate and build locally on port 4188
+
+## Session July 15, 2026 (Add Guaraní and Camino Rojo categories)
+
+- [x] Insert the Guaraní subcategory under the Languages category directly in production database
+- [x] Insert the Camino Rojo subcategory under the Lineage & Tradition category directly in production database
+- [x] Update database schema setup file `docs/design/db-schema.sql` to include the categories and bump version to v2.7
+- [x] Update existing seed/script files (`scripts/random-seeder.mjs` and legacy SQL) with the new categories

--- a/docs/logbook/master-timetracking.md
+++ b/docs/logbook/master-timetracking.md
@@ -76,7 +76,8 @@
 | **Jul 14 (Part 2)** | **UX & CI/CD**: Implement search debounce safeguards, client-side query timeout protection, Next.js build fixes, Vercel preview config, and git submodule alignment | ~3.5 Hours | ✅ Completed |
 | **Jul 14 (Part 3)** | **E2E & Submodule Polish**: Resolve lint/typing issues in E2E tests, update parent submodule reference, and run synchronization workflows | ~0.75 Hours | ✅ Completed |
 | **July 14, 2026** | **Mobile UI Overflow Fixes (Issue #188)**: Resolved mobile horizontal overflow on playlist cards, grid layout containers, and form inputs | ~1.5 Hours | ✅ Completed |
+| **July 15, 2026** | **Database tags update**: Add Guaraní and Camino Rojo categories to production database and update setup/seed files | ~0.5 Hours | ✅ Completed |
 
-| **Total** | **Development + AI Collaboration** | **~147.25 Hours** | |
+| **Total** | **Development + AI Collaboration** | **~147.75 Hours** | |
 
 

--- a/docs/logbook/master-walkthrough.md
+++ b/docs/logbook/master-walkthrough.md
@@ -2655,3 +2655,11 @@ This session addressed a critical bug where slow Supabase Auth calls (due to Tai
 - Updated `components/song/SongForm.tsx` to reduce mobile padding (`p-4 sm:p-6`) and wrap the `ChordProEditor` inside an `overflow-hidden w-full max-w-full min-w-0` container, forcing chords to scroll internally.
 - Set Key/Capo/Tuning grids to stack on mobile (`grid-cols-1 sm:grid-cols-3`) to avoid layout squishing on viewports below 400px.
 - Stacked save/publish action buttons vertically on mobile screens using `flex-col sm:flex-row`.
+
+## July 15, 2026 (Add Guaraní and Camino Rojo categories)
+
+### 1. Database Seed Updates
+- Directly updated the production and staging databases to insert "Guaraní" (Languages category) and "Camino Rojo" (Lineage & Tradition category) subcategories.
+- Updated the consolidated database schema setup [db-schema.sql](file:///home/roeland/projects/sacred-fire-songs/docs/design/db-schema.sql) to include the new categories in the master seed block and bumped the file version to `2.7`.
+- Updated the programmatic database seeder [random-seeder.mjs](file:///home/roeland/projects/sacred-fire-songs/scripts/random-seeder.mjs) and legacy category script [categories.sql](file:///home/roeland/projects/sacred-fire-songs/data/scripts/legacy/categories.sql) to include the new category insertions.
+

--- a/scripts/random-seeder.mjs
+++ b/scripts/random-seeder.mjs
@@ -88,11 +88,13 @@ BEGIN
         SELECT 'Spanish', 'spanish', '🇪🇸', id FROM public.categories WHERE slug = 'languages' UNION ALL
         SELECT 'Portuguese', 'portuguese', '🇵🇹', id FROM public.categories WHERE slug = 'languages' UNION ALL
         SELECT 'Sanskrit', 'sanskrit', '🇮🇳', id FROM public.categories WHERE slug = 'languages' UNION ALL
+        SELECT 'Guaraní', 'guarani', '🏹', id FROM public.categories WHERE slug = 'languages' UNION ALL
         
         SELECT 'Andean', 'andean', '🏔️', id FROM public.categories WHERE slug = 'lineage-tradition' UNION ALL
         SELECT 'Lakota', 'lakota', '🪶', id FROM public.categories WHERE slug = 'lineage-tradition' UNION ALL
         SELECT 'Santo Daime', 'santo-daime', '🌟', id FROM public.categories WHERE slug = 'lineage-tradition' UNION ALL
         SELECT 'Umbanda', 'umbanda', '🌊', id FROM public.categories WHERE slug = 'lineage-tradition' UNION ALL
+        SELECT 'Camino Rojo', 'camino-rojo', '🔴', id FROM public.categories WHERE slug = 'lineage-tradition' UNION ALL
         
         SELECT 'Ayahuasca', 'ayahuasca', '🍵', id FROM public.categories WHERE slug = 'medicine-healing' UNION ALL
         SELECT 'Peyote', 'peyote', '🌵', id FROM public.categories WHERE slug = 'medicine-healing' UNION ALL


### PR DESCRIPTION
Directly executed insertions on staging and production databases. Also updated existing categories seeds (db-schema.sql, random-seeder.mjs, and legacy categories.sql) to include the new categories.