### PR TITLE
feat(rehearsals): add personal rehearsal recordings, audio file uploads, filtering, and drag-and-drop sorting

### DIFF
--- a/app/library/playlists/page.tsx
+++ b/app/library/playlists/page.tsx
@@ -1,6 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import Link from 'next/link';
-import { Heart, ListMusic, Flame, Droplets, Lock, Globe, PenLine, Music, Plus, LogIn } from 'lucide-react';
+import { Heart, ListMusic, Flame, Droplets, Lock, Globe, PenLine, Music, Plus, LogIn, Mic } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { CreatePlaylistInput } from '@/components/playlists/CreatePlaylistInput';
 import { PlaylistCard } from '@/components/playlists/PlaylistCard';
@@ -38,6 +38,13 @@ const accentClasses = {
         icon:      'bg-rose-500/15',
         iconHover: 'group-hover:bg-rose-500/25',
         iconText:  'text-rose-400 fill-rose-400',
+    },
+    amber: {
+        card:      'bg-amber-500/8 border-amber-500/20',
+        cardHover: 'hover:bg-amber-500/15 hover:border-amber-500/35',
+        icon:      'bg-amber-500/15',
+        iconHover: 'group-hover:bg-amber-500/25',
+        iconText:  'text-amber-400',
     },
     violet: {
         card:      'bg-violet-500/8 border-violet-500/20',
@@ -105,26 +112,24 @@ function PublicPlaylistsSection({
     songCounts: Record<string, number>;
     songTitles: Record<string, string[]>;
 }) {
+    if (playlists.length === 0) return null;
+
     return (
         <div>
             <p className="text-[10px] font-bold text-gray-600 uppercase tracking-widest mb-3">Public Playlists</p>
-            {playlists.length === 0 ? (
-                <p className="text-sm text-gray-600 italic py-2">No public playlists yet.</p>
-            ) : (
-                <div className="grid grid-cols-1 gap-3">
-                    {playlists.map(pl => (
-                        <PublicPlaylistCard
-                            key={pl.id}
-                            id={pl.id}
-                            title={pl.title}
-                            description={pl.description}
-                            isOwner={!!userId && pl.owner_id === userId}
-                            songCount={songCounts[pl.id] ?? 0}
-                            songTitles={songTitles[pl.id] ?? []}
-                        />
-                    ))}
-                </div>
-            )}
+            <div className="grid grid-cols-1 gap-3">
+                {playlists.map(setlist => (
+                    <PublicPlaylistCard
+                        key={setlist.id}
+                        id={setlist.id}
+                        title={setlist.title}
+                        description={setlist.description}
+                        songCount={songCounts[setlist.id] ?? 0}
+                        songTitles={songTitles[setlist.id] ?? []}
+                        isOwner={userId === setlist.owner_id}
+                    />
+                ))}
+            </div>
         </div>
     );
 }
@@ -143,9 +148,10 @@ function GuestView({ publicPlaylists, publicSongCounts, publicSongTitles }: {
             <div>
                 <p className="text-[10px] font-bold text-gray-600 uppercase tracking-widest mb-3">Smart Playlists</p>
                 <div className="grid grid-cols-1 gap-3">
-                    <SmartPlaylistCard icon={Heart}   title="My Favorites" description="Your favorited songs, always with you"      subtitle={<span className="text-xs text-gray-500">No songs yet — tap ♥ on any song</span>} accent="rose"   />
+                    <SmartPlaylistCard icon={Heart}   title="My Favorites" description="Your favorited songs, always with you"      subtitle={<span className="text-xs text-gray-500">Sign in to save favorites</span>} accent="rose"   />
                     <SmartPlaylistCard icon={Music}   title="My Songs"     description="Songs you've contributed to the library"    subtitle={<span className="text-xs text-gray-500">Sign in to see your songs</span>} accent="violet" />
                     <SmartPlaylistCard icon={PenLine} title="My Drafts"    description="Your private work-in-progress songs"        subtitle={<span className="text-xs text-gray-500">Sign in to see your drafts</span>} accent="gray"   />
+                    <SmartPlaylistCard icon={Mic}     title="My Recordings" description="Your private rehearsal recordings"       subtitle={<span className="text-xs text-gray-500">Sign in to see your recordings</span>} accent="amber" />
                 </div>
             </div>
 
@@ -301,10 +307,11 @@ export default async function PlaylistsPage() {
         ? (songTitles[myFavorites.id] ?? []).slice(0, 5)
         : [];
 
-    // Fetch My Songs + My Drafts counts and titles, plus personalized sections
-    const [mySongsResult, myDraftsResult, recentlyViewedSongs, recentlyViewedCount, newSongs] = await Promise.all([
+    // Fetch My Songs + My Drafts + My Recordings counts and titles, plus personalized sections
+    const [mySongsResult, myDraftsResult, myRecordingsResult, recentlyViewedSongs, recentlyViewedCount, newSongs] = await Promise.all([
         supabase.from('compositions').select('title, is_public').eq('owner_id', user.id).limit(500),
         supabase.from('compositions').select('title, is_public').eq('is_public', false).limit(500),
+        supabase.from('user_recordings').select('song_versions(compositions(title, is_public))').eq('user_id', user.id),
         getRecentlyViewed(user.id, 5),
         getRecentlyViewedCount(user.id),
         getUnviewedSongs(user.id, 5),
@@ -325,6 +332,19 @@ export default async function PlaylistsPage() {
         draft: myDraftsData.length,
     };
     const myDraftsTitles = myDraftsData.slice(0, 5).map(s => s.title);
+
+    // Compute My Recordings counts and titles
+    const myRecordingsData = (myRecordingsResult.data ?? []).map(r => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (r.song_versions as any)?.compositions;
+    }).filter(Boolean);
+
+    const myRecordingsCounts: SongCounts = {
+        total: myRecordingsData.length,
+        public: myRecordingsData.filter(s => s?.is_public).length,
+        draft: myRecordingsData.filter(s => s && !s.is_public).length,
+    };
+    const myRecordingsTitles = Array.from(new Set(myRecordingsData.map(s => s?.title).filter(Boolean))).slice(0, 5) as string[];
 
     return (
         <div className="space-y-8">
@@ -350,6 +370,12 @@ export default async function PlaylistsPage() {
                         href="/songs?status=draft"
                         subtitle={<SongCountSubtitle counts={myDraftsCounts} emptyLabel="No drafts yet" />}
                         songTitles={myDraftsTitles}
+                    />
+                    <SmartPlaylistCard
+                        icon={Mic} title="My Recordings" description="Your private rehearsal recordings" accent="amber"
+                        href="/songs?myRecordings=true"
+                        subtitle={<SongCountSubtitle counts={myRecordingsCounts} emptyLabel="No recordings yet" />}
+                        songTitles={myRecordingsTitles}
                     />
                 </div>
             </div>

--- a/app/library/playlists/page.tsx
+++ b/app/library/playlists/page.tsx
@@ -151,7 +151,8 @@ function GuestView({ publicPlaylists, publicSongCounts, publicSongTitles }: {
                     <SmartPlaylistCard icon={Heart}   title="My Favorites" description="Your favorited songs, always with you"      subtitle={<span className="text-xs text-gray-500">Sign in to save favorites</span>} accent="rose"   />
                     <SmartPlaylistCard icon={Music}   title="My Songs"     description="Songs you've contributed to the library"    subtitle={<span className="text-xs text-gray-500">Sign in to see your songs</span>} accent="violet" />
                     <SmartPlaylistCard icon={PenLine} title="My Drafts"    description="Your private work-in-progress songs"        subtitle={<span className="text-xs text-gray-500">Sign in to see your drafts</span>} accent="gray"   />
-                    <SmartPlaylistCard icon={Mic}     title="My Recordings" description="Your private rehearsal recordings"       subtitle={<span className="text-xs text-gray-500">Sign in to see your recordings</span>} accent="amber" />
+                    <SmartPlaylistCard icon={Mic} title="My Recordings" description="Your private rehearsal recordings" accent="violet"
+                        subtitle={<span className="text-xs text-gray-500">Sign in to see your recordings</span>} />
                 </div>
             </div>
 
@@ -372,7 +373,7 @@ export default async function PlaylistsPage() {
                         songTitles={myDraftsTitles}
                     />
                     <SmartPlaylistCard
-                        icon={Mic} title="My Recordings" description="Your private rehearsal recordings" accent="amber"
+                        icon={Mic} title="My Recordings" description="Your private rehearsal recordings" accent="violet"
                         href="/songs?myRecordings=true"
                         subtitle={<SongCountSubtitle counts={myRecordingsCounts} emptyLabel="No recordings yet" />}
                         songTitles={myRecordingsTitles}

--- a/app/songs/SongsPageContent.tsx
+++ b/app/songs/SongsPageContent.tsx
@@ -13,6 +13,7 @@ import { type TaxonomyNode } from "@/lib/taxonomyUtils";
 import type { Song } from "@/lib/songUtils";
 import { useSongsQuery } from "@/hooks/useSongsQuery";
 import { useFavoritesQuery } from "@/hooks/useFavoritesQuery";
+import { useRecordingsQuery } from "@/hooks/useRecordingsQuery";
 import { useSongsFilter } from "@/hooks/useSongsFilter";
 import { isDraftActive } from "@/lib/songs/filterConfig";
 
@@ -54,6 +55,7 @@ export default function SongsPageContent({ initialSongs, initialTaxonomy, initia
             tags: [],
             chords: false,
             melody: false,
+            myRecordings: false,
             favorites: false,
             mine: false,
             new: false,
@@ -67,7 +69,9 @@ export default function SongsPageContent({ initialSongs, initialTaxonomy, initia
     const { songs, taxonomy } = useSongsQuery({ initialSongs, initialTaxonomy });
     
     const { favoriteIds } = useFavoritesQuery(user?.id);
+    const { userRecordingCompositionIds } = useRecordingsQuery(user?.id);
     const viewedSongIds = useMemo(() => new Set(initialViewedSongIds), [initialViewedSongIds]);
+
     const {
         displaySongs,
         state,
@@ -80,7 +84,7 @@ export default function SongsPageContent({ initialSongs, initialTaxonomy, initia
         mineCount,
         hasActiveFilters,
         filteredCount
-    } = useSongsFilter({ songs, userId: user?.id, favoriteIds, viewedSongIds, sortBy });
+    } = useSongsFilter({ songs, userId: user?.id, favoriteIds, userRecordingCompositionIds, viewedSongIds, sortBy });
 
     const handleDelete = async () => {
         if (!deleteTarget) return;
@@ -199,6 +203,7 @@ export default function SongsPageContent({ initialSongs, initialTaxonomy, initia
                                         isPublic={song.isPublic}
                                         hasChords={song.hasChords}
                                         hasMelody={song.hasMelody}
+                                        hasPersonalRecording={userRecordingCompositionIds.has(song.id)}
                                         isFavorite={favoriteIds.has(song.id)}
                                         userId={user?.id}
                                         categories={song.categories}

--- a/app/songs/SongsPageContent.tsx
+++ b/app/songs/SongsPageContent.tsx
@@ -82,6 +82,7 @@ export default function SongsPageContent({ initialSongs, initialTaxonomy, initia
         melodyCount,
         favoritesCount,
         mineCount,
+        recordingsCount,
         hasActiveFilters,
         filteredCount
     } = useSongsFilter({ songs, userId: user?.id, favoriteIds, userRecordingCompositionIds, viewedSongIds, sortBy });
@@ -290,6 +291,7 @@ export default function SongsPageContent({ initialSongs, initialTaxonomy, initia
                 melodyCount={melodyCount}
                 favoritesCount={favoritesCount}
                 mineCount={mineCount}
+                recordingsCount={recordingsCount}
                 hasActiveFilters={draft ? isDraftActive({ ...draft, search: localSearch }, user?.id) : hasActiveFilters}
                 isAuthenticated={!!user}
                 localSearch={localSearch}

--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -22,6 +22,7 @@ import { getCategoryColor, getCategoryStyles } from '@/lib/uiUtils';
 import { TagPill } from '@/components/ui/TagPill';
 import { AuthorPill } from '@/components/ui/AuthorPill';
 import { recordSongView } from '@/app/actions/recordSongView';
+import { useRecordingsQuery } from '@/hooks/useRecordingsQuery';
 
 // Enforce a timeout on any promise to prevent infinite loading skeletons
 function withTimeout<T>(promise: Promise<T>, ms: number, errorMessage = "Request timed out"): Promise<T> {
@@ -166,6 +167,10 @@ export default function SongDetailPage() {
         enabled: !!user,
     });
     const { isFav, handleToggle: handleToggleFavorite } = useToggleFavorite(id!, favoriteIds.has(id!));
+
+    // Personal recordings — check if logged-in user has any recordings for this song's composition
+    const { userRecordingCompositionIds } = useRecordingsQuery(user?.id);
+    const hasPersonalRecording = !!id && userRecordingCompositionIds.has(id);
 
     const titleRef = useRef<HTMLSpanElement>(null);
     const [scrollAmount, setScrollAmount] = useState(0);
@@ -340,6 +345,11 @@ export default function SongDetailPage() {
                                             <Music className="w-3 h-3" /> Melody
                                         </Link>
                                     )}
+                                    {hasPersonalRecording && (
+                                        <Link href="/songs?myRecordings=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-violet-500/5 border border-violet-500/30 text-violet-400 hover:bg-violet-500/15 transition-colors">
+                                            <Mic className="w-3 h-3" /> My Recording
+                                        </Link>
+                                    )}
                                 </div>
                             </div>
                             <div className="flex items-center gap-3 flex-wrap">
@@ -446,6 +456,11 @@ export default function SongDetailPage() {
                                 {song.has_melody && (
                                     <Link href="/songs?melody=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-emerald-500/5 border border-emerald-500/30 text-emerald-500 hover:bg-emerald-500/15 transition-colors">
                                         <Music className="w-3 h-3" /> Melody
+                                    </Link>
+                                )}
+                                {hasPersonalRecording && (
+                                    <Link href="/songs?myRecordings=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-violet-500/5 border border-violet-500/30 text-violet-400 hover:bg-violet-500/15 transition-colors">
+                                        <Mic className="w-3 h-3" /> My Recording
                                     </Link>
                                 )}
                             </div>

--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -20,6 +20,7 @@ import { SONG_KEYS } from '@/lib/songs/queryKeys';
 import { useWakeLock } from '@/hooks/useWakeLock';
 import { getCategoryColor, getCategoryStyles } from '@/lib/uiUtils';
 import { TagPill } from '@/components/ui/TagPill';
+import { AuthorPill } from '@/components/ui/AuthorPill';
 import { recordSongView } from '@/app/actions/recordSongView';
 
 // Enforce a timeout on any promise to prevent infinite loading skeletons
@@ -299,10 +300,6 @@ export default function SongDetailPage() {
                             {song.title}
                         </span>
                     </div>
-                    {/* Author */}
-                    <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 truncate mt-0.5">
-                        by {song.original_author || 'Traditional'}
-                    </div>
                 </div>
                 {/* 3-dot menu — flex-none so it never shrinks */}
                 <div className="flex-none flex items-center">
@@ -345,12 +342,8 @@ export default function SongDetailPage() {
                                     )}
                                 </div>
                             </div>
-                            <div className="flex items-center gap-3">
-                                <p className="text-gray-500 dark:text-gray-400 text-sm font-medium">by{' '}
-                                    <Link href={`/songs?artist=${encodeURIComponent(song.original_author || 'Traditional')}`} className="hover:text-gray-900 dark:hover:text-white hover:underline transition-colors">
-                                        {song.original_author || 'Traditional'}
-                                    </Link>
-                                </p>
+                            <div className="flex items-center gap-3 flex-wrap">
+                                <AuthorPill author={song.original_author || 'Traditional'} />
                                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                                 {categories.map((cat: any) => (
                                     <TagPill
@@ -457,8 +450,9 @@ export default function SongDetailPage() {
                                 )}
                             </div>
 
-                            {/* Category Tags */}
-                            <div className="flex items-center gap-2">
+                            {/* Author & Category Tags */}
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <AuthorPill author={song.original_author || 'Traditional'} />
                                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                                 {categories.map((cat: any) => (
                                     <TagPill

--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -347,7 +347,7 @@ export default function SongDetailPage() {
                                     )}
                                     {hasPersonalRecording && (
                                         <Link href="/songs?myRecordings=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-violet-500/5 border border-violet-500/30 text-violet-400 hover:bg-violet-500/15 transition-colors">
-                                            <Mic className="w-3 h-3" /> My Recording
+                                            <Mic className="w-3 h-3" /> Recording
                                         </Link>
                                     )}
                                 </div>
@@ -460,7 +460,7 @@ export default function SongDetailPage() {
                                 )}
                                 {hasPersonalRecording && (
                                     <Link href="/songs?myRecordings=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-violet-500/5 border border-violet-500/30 text-violet-400 hover:bg-violet-500/15 transition-colors">
-                                        <Mic className="w-3 h-3" /> My Recording
+                                        <Mic className="w-3 h-3" /> Recording
                                     </Link>
                                 )}
                             </div>

--- a/app/songs/[id]/page.tsx
+++ b/app/songs/[id]/page.tsx
@@ -10,7 +10,7 @@ import SongDetailSkeleton from '@/components/song/SongDetailSkeleton';
 import MediaEmbeds from '@/components/song/MediaEmbeds';
 import DeleteConfirmationModal from '@/components/common/DeleteConfirmationModal';
 import { useQuery } from '@tanstack/react-query';
-import { Trash2, Edit2, Music, Link as LinkIcon, Heart, MoreVertical, ListPlus, Mic, Share2 } from 'lucide-react';
+import { Trash2, Edit2, Music, Guitar, Heart, MoreVertical, ListPlus, Mic, Share2 } from 'lucide-react';
 import { toast } from 'sonner';
 import RehearsalDrawer from '@/components/song/RehearsalDrawer';
 import { useToggleFavorite } from '@/hooks/useToggleFavorite';
@@ -332,7 +332,7 @@ export default function SongDetailPage() {
                                 <div className="flex items-center gap-2">
                                     {song.has_chords && (
                                         <Link href="/songs?chords=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-amber-500/5 border border-amber-500/30 text-amber-500 hover:bg-amber-500/15 transition-colors">
-                                            <LinkIcon className="w-3 h-3" /> Chords
+                                            <Guitar className="w-3 h-3" /> Chords
                                         </Link>
                                     )}
                                     {song.has_melody && (
@@ -440,7 +440,7 @@ export default function SongDetailPage() {
                             <div className="flex items-center gap-2">
                                 {song.has_chords && (
                                     <Link href="/songs?chords=true" className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-widest shadow-sm bg-amber-500/5 border border-amber-500/30 text-amber-500 hover:bg-amber-500/15 transition-colors">
-                                        <LinkIcon className="w-3 h-3" /> Chords
+                                        <Guitar className="w-3 h-3" /> Chords
                                     </Link>
                                 )}
                                 {song.has_melody && (

--- a/components/common/GlobalSearchModal.tsx
+++ b/components/common/GlobalSearchModal.tsx
@@ -9,6 +9,7 @@ import { fetchCategoryTree } from '@/lib/taxonomyUtils';
 import { SONG_KEYS } from '@/lib/songs/queryKeys';
 import SearchFiltersModal from '@/components/library/SearchFiltersModal';
 import type { SongFilterState } from '@/lib/songs/filterConfig';
+import { useRecordingsQuery } from '@/hooks/useRecordingsQuery';
 
 type SortByType = 'title' | 'author' | 'newest';
 
@@ -59,6 +60,10 @@ function GlobalSearchModalInner({
         enabled: isOpen, // only fetch when modal is open
     });
 
+    // Personal recordings count — lightweight query, just the composition IDs
+    const { userRecordingCompositionIds } = useRecordingsQuery(userId);
+    const recordingsCount = userRecordingCompositionIds.size || undefined;
+
     // Local filter state (not URL-synced)
     const [localSearch, setLocalSearch] = useState('');
     const [sortBy, setSortBy] = useState<SortByType>('title');
@@ -69,9 +74,11 @@ function GlobalSearchModalInner({
         tags: [],
         chords: false,
         melody: false,
+        myRecordings: false,
         favorites: false,
         mine: false,
         new: false,
+        artist: '',
     });
 
     const setFilter = useCallback(<K extends keyof SongFilterState>(key: K, value: SongFilterState[K]) => {
@@ -86,9 +93,11 @@ function GlobalSearchModalInner({
             tags: [],
             chords: false,
             melody: false,
+            myRecordings: false,
             favorites: false,
             mine: false,
             new: false,
+            artist: '',
         });
     }, [userId]);
 
@@ -97,6 +106,7 @@ function GlobalSearchModalInner({
         (state.tags?.length ?? 0) > 0 ||
         state.chords ||
         state.melody ||
+        state.myRecordings ||
         state.favorites ||
         state.mine ||
         state.new ||
@@ -114,6 +124,7 @@ function GlobalSearchModalInner({
         }
         if (state.chords) params.set('chords', 'true');
         if (state.melody) params.set('melody', 'true');
+        if (state.myRecordings) params.set('myRecordings', 'true');
         if (state.favorites) params.set('favorites', 'true');
         if (state.mine) params.set('mine', 'true');
         if (state.new) params.set('new', 'true');
@@ -139,6 +150,7 @@ function GlobalSearchModalInner({
             melodyCount={undefined}
             favoritesCount={undefined}
             mineCount={undefined}
+            recordingsCount={recordingsCount}
             hasActiveFilters={hasActiveFilters}
             isAuthenticated={isAuthenticated}
             localSearch={localSearch}

--- a/components/common/GlobalSearchModal.tsx
+++ b/components/common/GlobalSearchModal.tsx
@@ -10,6 +10,7 @@ import { SONG_KEYS } from '@/lib/songs/queryKeys';
 import SearchFiltersModal from '@/components/library/SearchFiltersModal';
 import type { SongFilterState } from '@/lib/songs/filterConfig';
 import { useRecordingsQuery } from '@/hooks/useRecordingsQuery';
+import { useGlobalFilterCounts } from '@/hooks/useGlobalFilterCounts';
 
 type SortByType = 'title' | 'author' | 'newest';
 
@@ -63,6 +64,9 @@ function GlobalSearchModalInner({
     // Personal recordings count — lightweight query, just the composition IDs
     const { userRecordingCompositionIds } = useRecordingsQuery(userId);
     const recordingsCount = userRecordingCompositionIds.size || undefined;
+
+    // All other filter counts — parallel COUNT queries, no full song list needed
+    const { chordsCount, melodyCount, favoritesCount, mineCount } = useGlobalFilterCounts(userId);
 
     // Local filter state (not URL-synced)
     const [localSearch, setLocalSearch] = useState('');
@@ -146,10 +150,10 @@ function GlobalSearchModalInner({
             sortBy={sortBy}
             setSortBy={setSortBy}
             taxonomy={taxonomy}
-            chordsCount={undefined}
-            melodyCount={undefined}
-            favoritesCount={undefined}
-            mineCount={undefined}
+            chordsCount={chordsCount}
+            melodyCount={melodyCount}
+            favoritesCount={favoritesCount}
+            mineCount={mineCount}
             recordingsCount={recordingsCount}
             hasActiveFilters={hasActiveFilters}
             isAuthenticated={isAuthenticated}

--- a/components/home/SongCard.tsx
+++ b/components/home/SongCard.tsx
@@ -124,7 +124,7 @@ export default function SongCard({
                                 </div>
                             )}
                             {hasPersonalRecording && (
-                                <div className="text-amber-400 mb-1" title="Personal Rehearsal Recording">
+                                <div className="text-violet-400 mb-1" title="Personal Rehearsal Recording">
                                     <Mic className="w-3.5 h-3.5" />
                                 </div>
                             )}

--- a/components/home/SongCard.tsx
+++ b/components/home/SongCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { Music, Guitar, Heart } from 'lucide-react';
+import { Music, Guitar, Heart, Mic } from 'lucide-react';
 import { getCategoryColor, getCategoryStyles } from '@/lib/uiUtils';
 import { TagPill } from '@/components/ui/TagPill';
+import { AuthorPill } from '@/components/ui/AuthorPill';
 import { cn } from '@/lib/utils';
 import { useToggleFavorite } from '@/hooks/useToggleFavorite';
 import { PlaylistPicker } from '@/components/playlists/PlaylistPicker';
@@ -17,6 +18,7 @@ interface SongCardProps {
     isPublic?: boolean;
     hasChords?: boolean;
     hasMelody?: boolean;
+    hasPersonalRecording?: boolean;
     isFavorite?: boolean;
     userId?: string;
     categories?: {
@@ -35,6 +37,7 @@ export default function SongCard({
     isPublic = true,
     hasChords = false,
     hasMelody = false,
+    hasPersonalRecording = false,
     isFavorite = false,
     userId,
     categories = []
@@ -91,9 +94,9 @@ export default function SongCard({
                                     </span>
                                 )}
                             </div>
-                            <p className="text-xs text-gray-500 truncate mb-3">
-                                {author || 'Unknown'}
-                            </p>
+                            <div className="mb-3">
+                                <AuthorPill author={author || 'Traditional'} />
+                            </div>
 
                             {/* Categories/Tags */}
                             <div className="flex flex-wrap items-center gap-1.5">
@@ -118,6 +121,11 @@ export default function SongCard({
                             {hasMelody && (
                                 <div className="text-blue-400 mb-1" title="Has Melody">
                                     <Music className="w-3.5 h-3.5" />
+                                </div>
+                            )}
+                            {hasPersonalRecording && (
+                                <div className="text-amber-400 mb-1" title="Personal Rehearsal Recording">
+                                    <Mic className="w-3.5 h-3.5" />
                                 </div>
                             )}
                             {songKey && (

--- a/components/home/SongCard.tsx
+++ b/components/home/SongCard.tsx
@@ -119,7 +119,7 @@ export default function SongCard({
                                 </div>
                             )}
                             {hasMelody && (
-                                <div className="text-blue-400 mb-1" title="Has Melody">
+                                <div className="text-emerald-400 mb-1" title="Has Melody">
                                     <Music className="w-3.5 h-3.5" />
                                 </div>
                             )}

--- a/components/library/SearchFiltersModal.tsx
+++ b/components/library/SearchFiltersModal.tsx
@@ -243,7 +243,7 @@ export default function SearchFiltersModal({
                                     onClick={() => setFilter('myRecordings', !state.myRecordings)}
                                     icon={<Mic className="w-4 h-4" strokeWidth={1.5} />}
                                     label="My Recordings"
-                                    activeColor="amber"
+                                    activeColor="violet"
                                 />
                             </div>
                         </section>

--- a/components/library/SearchFiltersModal.tsx
+++ b/components/library/SearchFiltersModal.tsx
@@ -22,6 +22,7 @@ interface SearchFiltersModalProps {
     melodyCount?: number;
     favoritesCount?: number;
     mineCount?: number;
+    recordingsCount?: number;
     hasActiveFilters: boolean;
     isAuthenticated: boolean;
     localSearch: string;
@@ -42,6 +43,7 @@ export default function SearchFiltersModal({
     melodyCount,
     favoritesCount,
     mineCount,
+    recordingsCount,
     hasActiveFilters,
     isAuthenticated,
     localSearch,
@@ -241,8 +243,10 @@ export default function SearchFiltersModal({
                                 <ToggleCard
                                     active={!!state.myRecordings}
                                     onClick={() => setFilter('myRecordings', !state.myRecordings)}
+                                    disabled={!state.myRecordings && recordingsCount === 0}
                                     icon={<Mic className="w-4 h-4" strokeWidth={1.5} />}
                                     label="My Recordings"
+                                    count={recordingsCount ? recordingsCount : undefined}
                                     activeColor="violet"
                                 />
                             </div>

--- a/components/library/SearchFiltersModal.tsx
+++ b/components/library/SearchFiltersModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { X, SlidersHorizontal, Guitar, Music, Heart, ChevronDown, Search } from 'lucide-react';
+import { X, SlidersHorizontal, Guitar, Music, Heart, ChevronDown, Search, Mic } from 'lucide-react';
 import TagSelector from '@/components/library/TagSelector';
 import type { TaxonomyNode } from '@/lib/taxonomyUtils';
 import type { SongFilterState } from '@/lib/songs/filterConfig';
@@ -237,6 +237,13 @@ export default function SearchFiltersModal({
                                     label="My Songs"
                                     count={mineCount ? mineCount : undefined}
                                     activeColor="violet"
+                                />
+                                <ToggleCard
+                                    active={!!state.myRecordings}
+                                    onClick={() => setFilter('myRecordings', !state.myRecordings)}
+                                    icon={<Mic className="w-4 h-4" strokeWidth={1.5} />}
+                                    label="My Recordings"
+                                    activeColor="amber"
                                 />
                             </div>
                         </section>

--- a/components/library/SearchFiltersModal.tsx
+++ b/components/library/SearchFiltersModal.tsx
@@ -326,15 +326,15 @@ function ToggleCard({
         <button
             onClick={onClick}
             disabled={disabled}
-            className={`flex items-center gap-3 px-4 py-3 rounded-xl border transition-all text-left ${active
+            className={`flex items-center gap-2.5 px-3.5 py-3 rounded-xl border transition-all text-left min-w-0 ${active
                 ? `${colors.active} shadow-sm`
                 : 'bg-gray-50 dark:bg-gray-900/50 border-gray-200 dark:border-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-700'
                 } disabled:opacity-40 disabled:cursor-not-allowed`}
         >
-            <span className={active ? colors.icon : ''}>{icon}</span>
-            <span className="text-sm font-semibold">{label}</span>
+            <span className={`shrink-0 ${active ? colors.icon : ''}`}>{icon}</span>
+            <span className="text-sm font-semibold truncate leading-tight flex-1">{label}</span>
             {count !== undefined && (
-                <span className="ml-auto px-1.5 py-0.5 rounded-full bg-gray-200 dark:bg-gray-800 text-gray-500 text-[10px] font-bold">
+                <span className="shrink-0 ml-auto px-1.5 py-0.5 rounded-full bg-gray-200 dark:bg-gray-800 text-gray-500 text-[10px] font-bold">
                     {count}
                 </span>
             )}

--- a/components/song/AudioRecorder.tsx
+++ b/components/song/AudioRecorder.tsx
@@ -288,7 +288,7 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
             type="file"
             ref={fileInputRef}
             onChange={handleFileSelect}
-            accept="audio/mp3,audio/mpeg,audio/wav,audio/ogg,audio/m4a,audio/webm,audio/aac,audio/flac"
+            accept="audio/*,.mp3,.wav,.ogg,.m4a,.webm,.opus,.flac,.aac"
             className="hidden"
           />
           <div className="p-3 rounded-full bg-violet-500/10 text-violet-500 mb-2 group-hover:scale-110 transition-transform">
@@ -298,7 +298,7 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
             Click to select an audio file
           </p>
           <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
-            Supports MP3, WAV, OGG, M4A, WEBM, FLAC (Max 25 MB)
+            Supports MP3, M4A, OPUS, FLAC, WAV, OGG, WEBM (Max 25 MB)
           </p>
         </div>
       )}

--- a/components/song/AudioRecorder.tsx
+++ b/components/song/AudioRecorder.tsx
@@ -282,7 +282,7 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
 
       {/* Mode: Upload View (when idle) */}
       {activeTab === "upload" && recordingState === "idle" && (
-        <div className="w-full flex flex-col items-center justify-center py-4 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-xl hover:border-violet-500/50 dark:hover:border-violet-500/50 transition-all group cursor-pointer"
+        <div className="w-full flex flex-col items-center justify-center py-4 px-4 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-xl hover:border-violet-500/50 dark:hover:border-violet-500/50 transition-all group cursor-pointer text-center"
              onClick={() => fileInputRef.current?.click()}>
           <input
             type="file"
@@ -297,7 +297,7 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
           <p className="text-xs font-semibold text-gray-800 dark:text-gray-200">
             Click to select an audio file
           </p>
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
+          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 max-w-[240px] leading-tight">
             Supports MP3, M4A, OPUS, FLAC, WAV, OGG, WEBM (Max 25 MB)
           </p>
         </div>

--- a/components/song/AudioRecorder.tsx
+++ b/components/song/AudioRecorder.tsx
@@ -200,21 +200,21 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
     }
 
     try {
-      const savedRecording = await uploadRehearsalRecording(
+      const { recording, error } = await uploadRehearsalRecording(
         songVersionId,
         recordingName.trim(),
         audioBlobRef.current
       );
 
-      if (savedRecording) {
-        onRecordingSaved(savedRecording);
+      if (recording) {
+        onRecordingSaved(recording);
         discardRecording();
       } else {
-        setErrorMsg("Failed to save recording to storage server. Please try again.");
+        setErrorMsg(error || "Failed to save recording to storage server. Please try again.");
       }
-    } catch (err) {
+    } catch (err: any) {
       console.error("[recorder] Upload error:", err);
-      setErrorMsg("An unexpected error occurred during upload.");
+      setErrorMsg(err?.message || "An unexpected error occurred during upload.");
     } finally {
       setIsUploading(false);
     }

--- a/components/song/AudioRecorder.tsx
+++ b/components/song/AudioRecorder.tsx
@@ -214,7 +214,8 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
       }
     } catch (err: any) {
       console.error("[recorder] Upload error:", err);
-      setErrorMsg(err?.message || "An unexpected error occurred during upload.");
+      const msg = typeof err === 'string' ? err : (err?.message || err?.error_description || JSON.stringify(err));
+      setErrorMsg(msg && msg !== '{}' ? msg : "An unexpected error occurred during upload.");
     } finally {
       setIsUploading(false);
     }

--- a/components/song/AudioRecorder.tsx
+++ b/components/song/AudioRecorder.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
-import { Mic, Square, Play, Pause, Trash2, CloudUpload, RotateCcw } from "lucide-react";
+import { Mic, Square, Play, Pause, Trash2, CloudUpload, RotateCcw, Upload, FileAudio } from "lucide-react";
 import { toast } from "sonner";
 import { uploadRehearsalRecording, type UserRecording } from "@/lib/actions/rehearsal";
 
@@ -11,6 +11,7 @@ interface AudioRecorderProps {
 }
 
 export default function AudioRecorder({ songVersionId, onRecordingSaved }: AudioRecorderProps) {
+  const [activeTab, setActiveTab] = useState<"record" | "upload">("record");
   const [recordingState, setRecordingState] = useState<"idle" | "recording" | "paused" | "stopped">("idle");
   const [duration, setDuration] = useState(0);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
@@ -23,6 +24,7 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
   const audioChunksRef = useRef<Blob[]>([]);
   const timerIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const audioBlobRef = useRef<Blob | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // Format seconds to mm:ss
   const formatTime = (seconds: number) => {
@@ -115,7 +117,6 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
       setRecordingState("recording");
       const timerIntervalMs = typeof window !== "undefined" && (window as any).__E2E_FAST_TIMER__ ? 10 : 1000;
 
-      // Start timer with 3-minute limit check (180 seconds)
       timerIntervalRef.current = setInterval(() => {
         setDuration((prev) => {
           if (prev + 1 >= 180) {
@@ -138,17 +139,14 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
       mediaRecorderRef.current.stop();
       setRecordingState("stopped");
       
-      // Clean up timer
       if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
-      
-      // Stop all tracks in the stream
       if (streamRef.current) {
         streamRef.current.getTracks().forEach((track) => track.stop());
       }
     }
   };
 
-  // Discard recording
+  // Discard recording / uploaded file
   const discardRecording = () => {
     setRecordingState("idle");
     setDuration(0);
@@ -156,6 +154,7 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
     audioBlobRef.current = null;
     setRecordingName("");
     setErrorMsg(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
 
     if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
     if (streamRef.current) {
@@ -163,14 +162,39 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
     }
   };
 
-  // Upload/Save recording
+  // Handle local file selection
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setErrorMsg(null);
+
+    // Limit to 25 MB for uploaded files
+    if (file.size > 25 * 1024 * 1024) {
+      setErrorMsg("Audio file size exceeds the 25 MB limit.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    audioBlobRef.current = file;
+    const localUrl = URL.createObjectURL(file);
+    setAudioUrl(localUrl);
+    setRecordingState("stopped");
+
+    // Clean up filename for default title (strip extension)
+    const defaultName = file.name.replace(/\.[^/.]+$/, "");
+    setRecordingName(defaultName || `Rehearsal - ${new Date().toLocaleDateString()}`);
+  };
+
+  // Upload/Save recording or file
   const saveRecording = async () => {
     if (!audioBlobRef.current) return;
     setIsUploading(true);
     setErrorMsg(null);
 
-    if (audioBlobRef.current.size > 10 * 1024 * 1024) {
-      setErrorMsg("Recording file size exceeds the 10 MB limit.");
+    const maxLimit = activeTab === "upload" ? 25 * 1024 * 1024 : 10 * 1024 * 1024;
+    if (audioBlobRef.current.size > maxLimit) {
+      setErrorMsg(`File size exceeds the ${activeTab === "upload" ? "25 MB" : "10 MB"} limit.`);
       setIsUploading(false);
       return;
     }
@@ -209,23 +233,82 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
   return (
     <div className="w-full p-6 bg-gray-50/50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-2xl flex flex-col items-center justify-center space-y-4 transition-all duration-300">
       
-      {/* Title */}
-      <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
-        <Mic className={`w-4 h-4 ${recordingState === 'recording' ? 'text-red-500 animate-pulse' : 'text-gray-400'}`} />
-        {recordingState === "idle" && "Ready to record rehearsal"}
-        {recordingState === "recording" && "Recording rehearsal..."}
-        {recordingState === "paused" && "Recording paused"}
-        {recordingState === "stopped" && "Review your recording"}
-      </h4>
+      {/* Record / Upload Tab Toggle (only shown when idle) */}
+      {recordingState === "idle" && (
+        <div className="flex bg-gray-200/60 dark:bg-gray-800/60 p-1 rounded-xl gap-1 text-xs font-semibold">
+          <button
+            onClick={() => { setActiveTab("record"); setErrorMsg(null); }}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-all ${
+              activeTab === "record"
+                ? "bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow-sm"
+                : "text-gray-500 hover:text-gray-900 dark:hover:text-white"
+            }`}
+          >
+            <Mic className="w-3.5 h-3.5" />
+            Record Audio
+          </button>
+          <button
+            onClick={() => { setActiveTab("upload"); setErrorMsg(null); }}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-all ${
+              activeTab === "upload"
+                ? "bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow-sm"
+                : "text-gray-500 hover:text-gray-900 dark:hover:text-white"
+            }`}
+          >
+            <Upload className="w-3.5 h-3.5" />
+            Upload File
+          </button>
+        </div>
+      )}
 
-      {/* Timer */}
-      <div className="text-3xl font-mono font-bold tracking-tight text-gray-900 dark:text-white">
-        {formatTime(duration)}
-      </div>
+      {/* Mode: Record View */}
+      {activeTab === "record" && (
+        <>
+          {/* Title */}
+          <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
+            <Mic className={`w-4 h-4 ${recordingState === 'recording' ? 'text-red-500 animate-pulse' : 'text-gray-400'}`} />
+            {recordingState === "idle" && "Ready to record rehearsal"}
+            {recordingState === "recording" && "Recording rehearsal..."}
+            {recordingState === "paused" && "Recording paused"}
+            {recordingState === "stopped" && "Review your recording"}
+          </h4>
 
-      {/* Local preview audio player */}
+          {/* Timer */}
+          <div className="text-3xl font-mono font-bold tracking-tight text-gray-900 dark:text-white">
+            {formatTime(duration)}
+          </div>
+        </>
+      )}
+
+      {/* Mode: Upload View (when idle) */}
+      {activeTab === "upload" && recordingState === "idle" && (
+        <div className="w-full flex flex-col items-center justify-center py-4 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-xl hover:border-violet-500/50 dark:hover:border-violet-500/50 transition-all group cursor-pointer"
+             onClick={() => fileInputRef.current?.click()}>
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileSelect}
+            accept="audio/mp3,audio/mpeg,audio/wav,audio/ogg,audio/m4a,audio/webm,audio/aac,audio/flac"
+            className="hidden"
+          />
+          <div className="p-3 rounded-full bg-violet-500/10 text-violet-500 mb-2 group-hover:scale-110 transition-transform">
+            <FileAudio className="w-6 h-6" />
+          </div>
+          <p className="text-xs font-semibold text-gray-800 dark:text-gray-200">
+            Click to select an audio file
+          </p>
+          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
+            Supports MP3, WAV, OGG, M4A, WEBM, FLAC (Max 25 MB)
+          </p>
+        </div>
+      )}
+
+      {/* Local preview audio player (shown for both recorded and uploaded files once stopped/selected) */}
       {audioUrl && recordingState === "stopped" && (
-        <div className="w-full flex justify-center py-2">
+        <div className="w-full flex flex-col items-center space-y-2 py-2">
+          <p className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+            <FileAudio className="w-3.5 h-3.5 text-violet-400" /> Preview Rehearsal Audio
+          </p>
           <audio src={audioUrl} controls className="w-full max-w-md h-10 accent-indigo-500 rounded-lg" />
         </div>
       )}
@@ -275,8 +358,8 @@ export default function AudioRecorder({ songVersionId, onRecordingSaved }: Audio
         </div>
       )}
 
-      {/* Recording Control Buttons */}
-      {recordingState !== "stopped" && (
+      {/* Recording Control Buttons (Record tab only) */}
+      {activeTab === "record" && recordingState !== "stopped" && (
         <div className="flex items-center justify-center gap-6 py-2">
           
           {/* Discard Button (visible only when recording/paused) */}

--- a/components/song/RehearsalDrawer.tsx
+++ b/components/song/RehearsalDrawer.tsx
@@ -1,15 +1,128 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useTransition } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Music, Trash2, Calendar, Play, Pause, Lock, RotateCcw, RotateCw } from "lucide-react";
+import { X, Music, Trash2, Calendar, Play, Pause, Lock, RotateCcw, RotateCw, GripVertical } from "lucide-react";
 import { toast } from "sonner";
 import AudioRecorder from "./AudioRecorder";
-import { getUserRecordings, deleteUserRecording, type UserRecording } from "@/lib/actions/rehearsal";
+import { getUserRecordings, deleteUserRecording, reorderUserRecordings, type UserRecording } from "@/lib/actions/rehearsal";
 import { getYouTubeEmbedUrl, getSpotifyEmbedUrl } from "./MediaEmbeds";
 import { useAuth } from "@/hooks/useAuth";
 import Link from "next/link";
 import { useQueryClient } from "@tanstack/react-query";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+function SortableRecordingItem({
+  rec,
+  activePlaybackId,
+  deletingId,
+  handleTogglePlay,
+  handleDelete,
+  formatDate,
+  isCustomSort,
+}: {
+  rec: UserRecording;
+  activePlaybackId: string | null;
+  deletingId: string | null;
+  handleTogglePlay: (id: string, url: string | undefined) => void;
+  handleDelete: (id: string, path: string) => void;
+  formatDate: (date: string) => string;
+  isCustomSort: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: rec.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-950 border border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700 transition-all duration-200 group"
+    >
+      {/* Drag handle (shown when custom sort is active) */}
+      {isCustomSort && (
+        <button
+          {...attributes}
+          {...listeners}
+          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-grab active:cursor-grabbing touch-none shrink-0 p-1 -ml-1"
+          aria-label="Drag to reorder"
+          title="Drag to reorder"
+        >
+          <GripVertical className="w-4 h-4" />
+        </button>
+      )}
+
+      {/* Play/Pause Button */}
+      <button
+        onClick={() => handleTogglePlay(rec.id, rec.audioUrl)}
+        className={`w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 active:scale-95 shadow-sm shrink-0 ${
+          activePlaybackId === rec.id
+            ? "bg-indigo-600 hover:bg-indigo-500 text-white"
+            : "bg-indigo-50 dark:bg-indigo-950/40 hover:bg-indigo-100 text-indigo-600 dark:text-indigo-400"
+        }`}
+      >
+        {activePlaybackId === rec.id ? (
+          <Pause className="w-4 h-4 fill-current" />
+        ) : (
+          <Play className="w-4 h-4 fill-current translate-x-0.5" />
+        )}
+      </button>
+
+      {/* Title and date */}
+      <div className="flex-1 min-w-0 text-left">
+        <h4 className="text-sm font-bold text-gray-900 dark:text-white truncate">
+          {rec.recording_name}
+        </h4>
+        <span className="text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-1.5 mt-0.5 font-medium">
+          <Calendar className="w-3 h-3" />
+          {formatDate(rec.created_at)}
+        </span>
+      </div>
+
+      {/* Delete Button */}
+      <button
+        onClick={() => handleDelete(rec.id, rec.storage_path)}
+        disabled={deletingId === rec.id}
+        className="p-2 rounded-xl text-gray-400 hover:text-red-500 hover:bg-red-500/10 transition-all active:scale-95 shrink-0"
+        title="Delete rehearsal"
+      >
+        {deletingId === rec.id ? (
+          <div className="w-4 h-4 border-2 border-red-500/30 border-t-red-500 rounded-full animate-spin" />
+        ) : (
+          <Trash2 className="w-4 h-4" />
+        )}
+      </button>
+    </div>
+  );
+}
 
 interface RehearsalDrawerProps {
   isOpen: boolean;
@@ -107,8 +220,33 @@ export default function RehearsalDrawer({
   }, [youtubeUrl, soundcloudUrl, spotifyUrl, user]);
 
   const [recordings, setRecordings] = useState<UserRecording[]>([]);
-  const [recordingsSort, setRecordingsSort] = useState<"newest" | "oldest" | "title">("newest");
+  const [recordingsSort, setRecordingsSort] = useState<"newest" | "oldest" | "title" | "custom">("newest");
   const [isLoading, setIsLoading] = useState(false);
+  const [isPendingOrder, startOrderTransition] = useTransition();
+
+  const dndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = recordings.findIndex((r) => r.id === active.id);
+    const newIndex = recordings.findIndex((r) => r.id === over.id);
+    const reordered = arrayMove(recordings, oldIndex, newIndex);
+
+    setRecordings(reordered);
+    setRecordingsSort("custom");
+
+    startOrderTransition(async () => {
+      const res = await reorderUserRecordings(reordered.map((r) => r.id));
+      if (!res.success) {
+        toast.error("Failed to save recording order");
+      }
+    });
+  };
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [activePlaybackId, setActivePlaybackId] = useState<string | null>(null);
   const [audioElements, setAudioElements] = useState<Record<string, HTMLAudioElement>>({});
@@ -675,12 +813,13 @@ export default function RehearsalDrawer({
                         {recordings.length > 1 && (
                           <select
                             value={recordingsSort}
-                            onChange={(e) => setRecordingsSort(e.target.value as "newest" | "oldest" | "title")}
+                            onChange={(e) => setRecordingsSort(e.target.value as "newest" | "oldest" | "title" | "custom")}
                             className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 text-gray-600 dark:text-gray-400 text-[11px] font-medium rounded-lg px-2 py-1 outline-none focus:ring-1 focus:ring-violet-500 transition-colors"
                           >
                             <option value="newest">Newest First</option>
                             <option value="oldest">Oldest First</option>
                             <option value="title">Title (A-Z)</option>
+                            <option value="custom">Custom Order (Drag & Drop)</option>
                           </select>
                         )}
                       </div>
@@ -725,59 +864,41 @@ export default function RehearsalDrawer({
                           </p>
                         </div>
                       ) : (
-                        <div className="space-y-2.5">
-                          {[...recordings].sort((a, b) => {
-                            if (recordingsSort === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-                            if (recordingsSort === "title") return a.recording_name.localeCompare(b.recording_name);
-                            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-                          }).map((rec) => (
-                            <div
-                              key={rec.id}
-                              className="flex items-center gap-4 p-4 rounded-2xl bg-gray-50 dark:bg-gray-950 border border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700 transition-all duration-200"
-                            >
-                              {/* Play/Pause Button */}
-                              <button
-                                onClick={() => handleTogglePlay(rec.id, rec.audioUrl)}
-                                className={`w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 active:scale-95 shadow-sm shrink-0 ${
-                                  activePlaybackId === rec.id
-                                    ? "bg-indigo-600 hover:bg-indigo-500 text-white"
-                                    : "bg-indigo-50 dark:bg-indigo-950/40 hover:bg-indigo-100 text-indigo-600 dark:text-indigo-400"
-                                }`}
-                              >
-                                {activePlaybackId === rec.id ? (
-                                  <Pause className="w-4 h-4 fill-current" />
-                                ) : (
-                                  <Play className="w-4 h-4 fill-current translate-x-0.5" />
-                                )}
-                              </button>
-
-                              {/* Title and date */}
-                              <div className="flex-1 min-w-0 text-left">
-                                <h4 className="text-sm font-bold text-gray-900 dark:text-white truncate">
-                                  {rec.recording_name}
-                                </h4>
-                                <span className="text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-1.5 mt-0.5 font-medium">
-                                  <Calendar className="w-3 h-3" />
-                                  {formatDate(rec.created_at)}
-                                </span>
-                              </div>
-
-                              {/* Delete Button */}
-                              <button
-                                onClick={() => handleDelete(rec.id, rec.storage_path)}
-                                disabled={deletingId === rec.id}
-                                className="p-2 rounded-xl text-gray-400 hover:text-red-500 hover:bg-red-500/10 transition-all active:scale-95 shrink-0"
-                                title="Delete rehearsal"
-                              >
-                                {deletingId === rec.id ? (
-                                  <div className="w-4 h-4 border-2 border-red-500/30 border-t-red-500 rounded-full animate-spin" />
-                                ) : (
-                                  <Trash2 className="w-4 h-4" />
-                                )}
-                              </button>
+                        <DndContext sensors={dndSensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                          <SortableContext
+                            items={(() => {
+                              if (recordingsSort === "custom") return recordings.map((r) => r.id);
+                              return [...recordings].sort((a, b) => {
+                                if (recordingsSort === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+                                if (recordingsSort === "title") return a.recording_name.localeCompare(b.recording_name);
+                                return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+                              }).map((r) => r.id);
+                            })()}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            <div className="space-y-2.5">
+                              {(recordingsSort === "custom"
+                                ? recordings
+                                : [...recordings].sort((a, b) => {
+                                    if (recordingsSort === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+                                    if (recordingsSort === "title") return a.recording_name.localeCompare(b.recording_name);
+                                    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+                                  })
+                              ).map((rec) => (
+                                <SortableRecordingItem
+                                  key={rec.id}
+                                  rec={rec}
+                                  activePlaybackId={activePlaybackId}
+                                  deletingId={deletingId}
+                                  handleTogglePlay={handleTogglePlay}
+                                  handleDelete={handleDelete}
+                                  formatDate={formatDate}
+                                  isCustomSort={recordingsSort === "custom" || recordings.length > 1}
+                                />
+                              ))}
                             </div>
-                          ))}
-                        </div>
+                          </SortableContext>
+                        </DndContext>
                       )}
                     </section>
                   </div>

--- a/components/song/RehearsalDrawer.tsx
+++ b/components/song/RehearsalDrawer.tsx
@@ -9,6 +9,7 @@ import { getUserRecordings, deleteUserRecording, type UserRecording } from "@/li
 import { getYouTubeEmbedUrl, getSpotifyEmbedUrl } from "./MediaEmbeds";
 import { useAuth } from "@/hooks/useAuth";
 import Link from "next/link";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface RehearsalDrawerProps {
   isOpen: boolean;
@@ -446,10 +447,14 @@ export default function RehearsalDrawer({
     };
   }, [isOpen, songVersionId]);
 
+  const queryClient = useQueryClient();
+
   // Handle new recording saved
   const handleRecordingSaved = (newRecording: UserRecording) => {
     setRecordings((prev) => [newRecording, ...prev]);
     toast.success("Rehearsal recording saved successfully!");
+    queryClient.invalidateQueries({ queryKey: ["user-recordings-compositions"] });
+    queryClient.invalidateQueries({ queryKey: ["global-filter-counts"] });
   };
 
   // Handle delete recording
@@ -465,6 +470,8 @@ export default function RehearsalDrawer({
       if (success) {
         setRecordings((prev) => prev.filter((r) => r.id !== recordingId));
         toast.success("Recording deleted.");
+        queryClient.invalidateQueries({ queryKey: ["user-recordings-compositions"] });
+        queryClient.invalidateQueries({ queryKey: ["global-filter-counts"] });
       } else {
         toast.error("Failed to delete recording.");
       }

--- a/components/song/RehearsalDrawer.tsx
+++ b/components/song/RehearsalDrawer.tsx
@@ -668,8 +668,8 @@ export default function RehearsalDrawer({
                     </section>
 
                     {/* Saved Practice Takes List */}
-                    <section className="space-y-3">
-                      <h3 className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-left">My Saved Takes</h3>
+                    <section className="mt-6 space-y-3">
+                      <h3 className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-left">My Recordings</h3>
                       
                       {/* Fake practice takes mock list for guest demo preview */}
                       {!user ? (

--- a/components/song/RehearsalDrawer.tsx
+++ b/components/song/RehearsalDrawer.tsx
@@ -220,7 +220,6 @@ export default function RehearsalDrawer({
   }, [youtubeUrl, soundcloudUrl, spotifyUrl, user]);
 
   const [recordings, setRecordings] = useState<UserRecording[]>([]);
-  const [recordingsSort, setRecordingsSort] = useState<"newest" | "oldest" | "title" | "custom">("newest");
   const [isLoading, setIsLoading] = useState(false);
   const [isPendingOrder, startOrderTransition] = useTransition();
 
@@ -238,7 +237,6 @@ export default function RehearsalDrawer({
     const reordered = arrayMove(recordings, oldIndex, newIndex);
 
     setRecordings(reordered);
-    setRecordingsSort("custom");
 
     startOrderTransition(async () => {
       const res = await reorderUserRecordings(reordered.map((r) => r.id));
@@ -808,21 +806,7 @@ export default function RehearsalDrawer({
 
                     {/* Saved Practice Takes List */}
                     <section className="mt-6 space-y-3">
-                      <div className="flex items-center justify-between">
-                        <h3 className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-left">My Recordings</h3>
-                        {recordings.length > 1 && (
-                          <select
-                            value={recordingsSort}
-                            onChange={(e) => setRecordingsSort(e.target.value as "newest" | "oldest" | "title" | "custom")}
-                            className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 text-gray-600 dark:text-gray-400 text-[11px] font-medium rounded-lg px-2 py-1 outline-none focus:ring-1 focus:ring-violet-500 transition-colors"
-                          >
-                            <option value="newest">Newest First</option>
-                            <option value="oldest">Oldest First</option>
-                            <option value="title">Title (A-Z)</option>
-                            <option value="custom">Custom Order (Drag & Drop)</option>
-                          </select>
-                        )}
-                      </div>
+                      <h3 className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-left">My Recordings</h3>
                       
                       {/* Fake practice takes mock list for guest demo preview */}
                       {!user ? (
@@ -866,25 +850,11 @@ export default function RehearsalDrawer({
                       ) : (
                         <DndContext sensors={dndSensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                           <SortableContext
-                            items={(() => {
-                              if (recordingsSort === "custom") return recordings.map((r) => r.id);
-                              return [...recordings].sort((a, b) => {
-                                if (recordingsSort === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-                                if (recordingsSort === "title") return a.recording_name.localeCompare(b.recording_name);
-                                return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-                              }).map((r) => r.id);
-                            })()}
+                            items={recordings.map((r) => r.id)}
                             strategy={verticalListSortingStrategy}
                           >
                             <div className="space-y-2.5">
-                              {(recordingsSort === "custom"
-                                ? recordings
-                                : [...recordings].sort((a, b) => {
-                                    if (recordingsSort === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-                                    if (recordingsSort === "title") return a.recording_name.localeCompare(b.recording_name);
-                                    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-                                  })
-                              ).map((rec) => (
+                              {recordings.map((rec) => (
                                 <SortableRecordingItem
                                   key={rec.id}
                                   rec={rec}
@@ -893,7 +863,7 @@ export default function RehearsalDrawer({
                                   handleTogglePlay={handleTogglePlay}
                                   handleDelete={handleDelete}
                                   formatDate={formatDate}
-                                  isCustomSort={recordingsSort === "custom" || recordings.length > 1}
+                                  isCustomSort={recordings.length > 1}
                                 />
                               ))}
                             </div>

--- a/components/song/RehearsalDrawer.tsx
+++ b/components/song/RehearsalDrawer.tsx
@@ -107,6 +107,7 @@ export default function RehearsalDrawer({
   }, [youtubeUrl, soundcloudUrl, spotifyUrl, user]);
 
   const [recordings, setRecordings] = useState<UserRecording[]>([]);
+  const [recordingsSort, setRecordingsSort] = useState<"newest" | "oldest" | "title">("newest");
   const [isLoading, setIsLoading] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [activePlaybackId, setActivePlaybackId] = useState<string | null>(null);
@@ -669,7 +670,20 @@ export default function RehearsalDrawer({
 
                     {/* Saved Practice Takes List */}
                     <section className="mt-6 space-y-3">
-                      <h3 className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-left">My Recordings</h3>
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-left">My Recordings</h3>
+                        {recordings.length > 1 && (
+                          <select
+                            value={recordingsSort}
+                            onChange={(e) => setRecordingsSort(e.target.value as "newest" | "oldest" | "title")}
+                            className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 text-gray-600 dark:text-gray-400 text-[11px] font-medium rounded-lg px-2 py-1 outline-none focus:ring-1 focus:ring-violet-500 transition-colors"
+                          >
+                            <option value="newest">Newest First</option>
+                            <option value="oldest">Oldest First</option>
+                            <option value="title">Title (A-Z)</option>
+                          </select>
+                        )}
+                      </div>
                       
                       {/* Fake practice takes mock list for guest demo preview */}
                       {!user ? (
@@ -712,7 +726,11 @@ export default function RehearsalDrawer({
                         </div>
                       ) : (
                         <div className="space-y-2.5">
-                          {recordings.map((rec) => (
+                          {[...recordings].sort((a, b) => {
+                            if (recordingsSort === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+                            if (recordingsSort === "title") return a.recording_name.localeCompare(b.recording_name);
+                            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+                          }).map((rec) => (
                             <div
                               key={rec.id}
                               className="flex items-center gap-4 p-4 rounded-2xl bg-gray-50 dark:bg-gray-950 border border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700 transition-all duration-200"

--- a/components/song/SongForm.tsx
+++ b/components/song/SongForm.tsx
@@ -338,6 +338,8 @@ const SongForm = ({ mode, initialData, songId, versionId }: SongFormProps) => {
             }
             queryClient.invalidateQueries({ queryKey: SONG_KEYS.all() });
             queryClient.invalidateQueries({ queryKey: SONG_KEYS.detail(id) });
+            // Bust global filter counts (chords/melody/mine may have changed)
+            queryClient.invalidateQueries({ queryKey: SONG_KEYS.globalFilterCounts() });
             const returnTo = mode === 'create' ? (searchParams.get('next') || '/') : `/songs/${id}`;
             router.push(returnTo);
         },

--- a/components/ui/AuthorPill.tsx
+++ b/components/ui/AuthorPill.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { User } from 'lucide-react';
+
+export interface AuthorPillProps {
+  author: string;
+  variant?: 'badge' | 'filter';
+  selected?: boolean;
+  count?: number;
+  onClick?: () => void;
+  href?: string;
+  className?: string;
+}
+
+export function AuthorPill({
+  author,
+  variant = 'badge',
+  selected = false,
+  count,
+  onClick,
+  href,
+  className = '',
+}: AuthorPillProps) {
+  const displayAuthor = author?.trim() || 'Traditional';
+  const targetHref = href || `/songs?artist=${encodeURIComponent(displayAuthor)}`;
+
+  const baseStyles =
+    'inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 select-none border cursor-pointer active:scale-95';
+
+  let variantStyles = '';
+  if (variant === 'badge') {
+    variantStyles =
+      'bg-indigo-500/10 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-300 border-indigo-500/30 hover:bg-indigo-500/20 dark:hover:bg-indigo-500/30 shadow-xs';
+  } else if (selected) {
+    variantStyles =
+      'bg-indigo-600 text-white border-indigo-600 shadow-md ring-1 ring-indigo-500/50';
+  } else {
+    variantStyles =
+      'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700';
+  }
+
+  const content = (
+    <>
+      <User className="w-3 h-3 shrink-0 opacity-80" />
+      <span>{displayAuthor}</span>
+      {typeof count === 'number' && (
+        <span
+          className={`text-[10px] px-1.5 py-0.5 rounded-full ${
+            selected
+              ? 'bg-white/20 text-white'
+              : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+          }`}
+        >
+          {count}
+        </span>
+      )}
+    </>
+  );
+
+  if (targetHref && !onClick) {
+    return (
+      <Link href={targetHref} className={`${baseStyles} ${variantStyles} ${className}`}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${baseStyles} ${variantStyles} ${className}`}
+    >
+      {content}
+    </button>
+  );
+}

--- a/hooks/useDeleteSong.ts
+++ b/hooks/useDeleteSong.ts
@@ -29,6 +29,8 @@ export function useDeleteSong() {
 
         // Invalidate all song lists so every page refetches
         await queryClient.invalidateQueries({ queryKey: SONG_KEYS.all() });
+        // Bust the global filter counts (chords/melody/mine may have changed)
+        queryClient.invalidateQueries({ queryKey: SONG_KEYS.globalFilterCounts() });
         router.refresh(); // also bust Next.js Router Cache for Server Components
 
         if (options?.redirectTo) {

--- a/hooks/useGlobalFilterCounts.ts
+++ b/hooks/useGlobalFilterCounts.ts
@@ -1,0 +1,85 @@
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/lib/supabase/client';
+import { SONG_KEYS } from '@/lib/songs/queryKeys';
+
+interface GlobalFilterCounts {
+  chordsCount: number | undefined;
+  melodyCount: number | undefined;
+  favoritesCount: number | undefined;
+  mineCount: number | undefined;
+}
+
+/**
+ * Fetches filter counts directly from Supabase for use on non-/songs pages
+ * where the full song list isn't loaded.  Uses lightweight COUNT queries.
+ *
+ * Note: counts are global (not cross-filter-aware like useSongsFilter).
+ * That's acceptable here since the modal navigates to /songs where exact
+ * cross-filter counts are recomputed from the live song list.
+ */
+export function useGlobalFilterCounts(userId?: string): GlobalFilterCounts {
+  const { data } = useQuery({
+    queryKey: SONG_KEYS.globalFilterCounts(userId),
+    queryFn: async (): Promise<GlobalFilterCounts> => {
+      const supabase = createClient();
+
+      // Run all queries in parallel
+      const [chordsResult, melodyResult, mineResult, favSetlistResult] = await Promise.all([
+        // Chords count — RLS filters to songs visible to this user
+        supabase
+          .from('compositions')
+          .select('id', { count: 'exact', head: true })
+          .eq('has_chords', true),
+
+        // Melody count — RLS filters to songs visible to this user
+        supabase
+          .from('compositions')
+          .select('id', { count: 'exact', head: true })
+          .eq('has_melody', true),
+
+        // Mine count — only makes sense when logged in
+        userId
+          ? supabase
+              .from('compositions')
+              .select('id', { count: 'exact', head: true })
+              .eq('owner_id', userId)
+          : Promise.resolve({ count: null, error: null }),
+
+        // Favorites — fetch setlist ID first
+        userId
+          ? supabase
+              .from('setlists')
+              .select('id')
+              .eq('title', 'My Favorites')
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+      ]);
+
+      // Favorites count: if we got a setlist, count its items
+      let favoritesCount: number | undefined = undefined;
+      if (userId && favSetlistResult && 'data' in favSetlistResult && favSetlistResult.data?.id) {
+        const { count } = await supabase
+          .from('setlist_items')
+          .select('id', { count: 'exact', head: true })
+          .eq('setlist_id', favSetlistResult.data.id);
+        favoritesCount = count ?? undefined;
+      }
+
+      return {
+        chordsCount: chordsResult.count ?? undefined,
+        melodyCount: melodyResult.count ?? undefined,
+        mineCount: userId ? (mineResult.count ?? undefined) : undefined,
+        favoritesCount,
+      };
+    },
+    enabled: true, // always fetch — chords/melody counts don't need auth
+    staleTime: 10 * 60_000, // 10 min — invalidated on song create/update/delete and favorite toggle
+  });
+
+  return {
+    chordsCount: data?.chordsCount,
+    melodyCount: data?.melodyCount,
+    favoritesCount: data?.favoritesCount,
+    mineCount: data?.mineCount,
+  };
+}

--- a/hooks/useGlobalFilterCounts.ts
+++ b/hooks/useGlobalFilterCounts.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import { SONG_KEYS } from '@/lib/songs/queryKeys';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 interface GlobalFilterCounts {
   chordsCount: number | undefined;
@@ -9,13 +10,59 @@ interface GlobalFilterCounts {
   mineCount: number | undefined;
 }
 
+// ─── Individual count queries ─────────────────────────────────────────────────
+
+async function fetchChordsCount(supabase: SupabaseClient): Promise<number | undefined> {
+  const { count } = await supabase
+    .from('compositions')
+    .select('id', { count: 'exact', head: true })
+    .eq('has_chords', true);
+  return count ?? undefined;
+}
+
+async function fetchMelodyCount(supabase: SupabaseClient): Promise<number | undefined> {
+  const { count } = await supabase
+    .from('compositions')
+    .select('id', { count: 'exact', head: true })
+    .eq('has_melody', true);
+  return count ?? undefined;
+}
+
+async function fetchMySongsCount(supabase: SupabaseClient, userId: string): Promise<number | undefined> {
+  const { count } = await supabase
+    .from('compositions')
+    .select('id', { count: 'exact', head: true })
+    .eq('owner_id', userId);
+  return count ?? undefined;
+}
+
+async function fetchFavoritesCount(supabase: SupabaseClient): Promise<number | undefined> {
+  const { data: setlist } = await supabase
+    .from('setlists')
+    .select('id')
+    .eq('title', 'My Favorites')
+    .maybeSingle();
+  if (!setlist?.id) return undefined;
+
+  const { count } = await supabase
+    .from('setlist_items')
+    .select('id', { count: 'exact', head: true })
+    .eq('setlist_id', setlist.id);
+  return count ?? undefined;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
 /**
- * Fetches filter counts directly from Supabase for use on non-/songs pages
- * where the full song list isn't loaded.  Uses lightweight COUNT queries.
+ * Fetches all filter badge counts directly from Supabase for use on non-/songs
+ * pages where the full song list isn't loaded in memory.
  *
- * Note: counts are global (not cross-filter-aware like useSongsFilter).
- * That's acceptable here since the modal navigates to /songs where exact
- * cross-filter counts are recomputed from the live song list.
+ * Counts are global (not cross-filter-aware like useSongsFilter). That's
+ * acceptable here since this modal navigates to /songs where exact cross-filter
+ * counts are recomputed from the live song list.
+ *
+ * Cache: 10-minute staleTime, invalidated on song create/update/delete and
+ * favorite toggle via SONG_KEYS.globalFilterCounts().
  */
 export function useGlobalFilterCounts(userId?: string): GlobalFilterCounts {
   const { data } = useQuery({
@@ -23,63 +70,24 @@ export function useGlobalFilterCounts(userId?: string): GlobalFilterCounts {
     queryFn: async (): Promise<GlobalFilterCounts> => {
       const supabase = createClient();
 
-      // Run all queries in parallel
-      const [chordsResult, melodyResult, mineResult, favSetlistResult] = await Promise.all([
-        // Chords count — RLS filters to songs visible to this user
-        supabase
-          .from('compositions')
-          .select('id', { count: 'exact', head: true })
-          .eq('has_chords', true),
-
-        // Melody count — RLS filters to songs visible to this user
-        supabase
-          .from('compositions')
-          .select('id', { count: 'exact', head: true })
-          .eq('has_melody', true),
-
-        // Mine count — only makes sense when logged in
-        userId
-          ? supabase
-              .from('compositions')
-              .select('id', { count: 'exact', head: true })
-              .eq('owner_id', userId)
-          : Promise.resolve({ count: null, error: null }),
-
-        // Favorites — fetch setlist ID first
-        userId
-          ? supabase
-              .from('setlists')
-              .select('id')
-              .eq('title', 'My Favorites')
-              .maybeSingle()
-          : Promise.resolve({ data: null, error: null }),
+      // Chords and melody counts don't require auth — run always
+      // My Songs and Favorites are only fetched when logged in
+      const [chordsCount, melodyCount, mineCount, favoritesCount] = await Promise.all([
+        fetchChordsCount(supabase),
+        fetchMelodyCount(supabase),
+        userId ? fetchMySongsCount(supabase, userId) : Promise.resolve(undefined),
+        userId ? fetchFavoritesCount(supabase)      : Promise.resolve(undefined),
       ]);
 
-      // Favorites count: if we got a setlist, count its items
-      let favoritesCount: number | undefined = undefined;
-      if (userId && favSetlistResult && 'data' in favSetlistResult && favSetlistResult.data?.id) {
-        const { count } = await supabase
-          .from('setlist_items')
-          .select('id', { count: 'exact', head: true })
-          .eq('setlist_id', favSetlistResult.data.id);
-        favoritesCount = count ?? undefined;
-      }
-
-      return {
-        chordsCount: chordsResult.count ?? undefined,
-        melodyCount: melodyResult.count ?? undefined,
-        mineCount: userId ? (mineResult.count ?? undefined) : undefined,
-        favoritesCount,
-      };
+      return { chordsCount, melodyCount, mineCount, favoritesCount };
     },
-    enabled: true, // always fetch — chords/melody counts don't need auth
-    staleTime: 10 * 60_000, // 10 min — invalidated on song create/update/delete and favorite toggle
+    staleTime: 10 * 60_000, // 10 min — invalidated on mutations, see SONG_KEYS.globalFilterCounts
   });
 
   return {
-    chordsCount: data?.chordsCount,
-    melodyCount: data?.melodyCount,
+    chordsCount:   data?.chordsCount,
+    melodyCount:   data?.melodyCount,
+    mineCount:     data?.mineCount,
     favoritesCount: data?.favoritesCount,
-    mineCount: data?.mineCount,
   };
 }

--- a/hooks/useRecordingsQuery.ts
+++ b/hooks/useRecordingsQuery.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/lib/supabase/client';
+
+export function useRecordingsQuery(userId?: string) {
+  const { data: userRecordingCompositionIds = new Set<string>() } = useQuery({
+    queryKey: ['user-recordings-compositions', userId],
+    queryFn: async () => {
+      if (!userId) return new Set<string>();
+      const supabase = createClient();
+      const { data: recordings } = await supabase
+        .from('user_recordings')
+        .select('song_version_id, song_versions(composition_id)')
+        .eq('user_id', userId);
+
+      const compIds = new Set<string>();
+      for (const item of recordings ?? []) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const compId = (item.song_versions as any)?.composition_id;
+        if (compId) compIds.add(compId);
+      }
+      return compIds;
+    },
+    enabled: !!userId,
+    staleTime: 30_000,
+  });
+
+  return { userRecordingCompositionIds };
+}

--- a/hooks/useSongsFilter.ts
+++ b/hooks/useSongsFilter.ts
@@ -92,24 +92,28 @@ export function useSongsFilter({ songs, userId, favoriteIds, userRecordingCompos
   // Cross-filter-aware counts: each count applies all OTHER active post-filters
   // but excludes its own, so users see "how many would match if I toggled this?"
   const toggleCounts = useMemo(() => {
-    let chords = 0, melody = 0, favorites = 0, mine = 0;
+    let chords = 0, melody = 0, favorites = 0, mine = 0, recordings = 0;
     for (const s of filteredItems) {
       const isFav = favoriteIds.has(s.id);
       const isMine = userId ? s.ownerId === userId : false;
+      const hasRec = userId ? userRecordingCompositionIds.has(s.id) : false;
       // Apply all active post-filters EXCEPT the one we're counting
       const matchFav = !state.favorites || isFav;
       const matchMine = !state.mine || !userId || isMine;
+      const matchRec = !state.myRecordings || !userId || hasRec;
 
-      // For chords/melody: must pass other post-filters
-      if (matchFav && matchMine && s.hasChords) chords++;
-      if (matchFav && matchMine && s.hasMelody) melody++;
-      // For favorites: must pass mine (skip favorites check)
-      if (matchMine && isFav) favorites++;
-      // For mine: must pass favorites (skip mine check)
-      if (matchFav && isMine) mine++;
+      // For chords/melody: must pass all other post-filters
+      if (matchFav && matchMine && matchRec && s.hasChords) chords++;
+      if (matchFav && matchMine && matchRec && s.hasMelody) melody++;
+      // For favorites: must pass mine + recordings (skip favorites check)
+      if (matchMine && matchRec && isFav) favorites++;
+      // For mine: must pass favorites + recordings (skip mine check)
+      if (matchFav && matchRec && isMine) mine++;
+      // For recordings: must pass favorites + mine (skip recordings check)
+      if (matchFav && matchMine && hasRec) recordings++;
     }
-    return { chords, melody, favorites, mine };
-  }, [filteredItems, favoriteIds, userId, state.favorites, state.mine]);
+    return { chords, melody, favorites, mine, recordings };
+  }, [filteredItems, favoriteIds, userRecordingCompositionIds, userId, state.favorites, state.mine, state.myRecordings]);
 
   const hasActiveFilters = isDraftActive(state, userId);
 
@@ -124,6 +128,7 @@ export function useSongsFilter({ songs, userId, favoriteIds, userRecordingCompos
     melodyCount: toggleCounts.melody,
     favoritesCount: toggleCounts.favorites,
     mineCount: toggleCounts.mine,
+    recordingsCount: toggleCounts.recordings,
     hasActiveFilters,
   };
 }

--- a/hooks/useSongsFilter.ts
+++ b/hooks/useSongsFilter.ts
@@ -9,11 +9,12 @@ interface UseSongsFilterOptions {
   songs: Song[];
   userId?: string;
   favoriteIds: Set<string>;
+  userRecordingCompositionIds?: Set<string>;
   viewedSongIds: Set<string>;
   sortBy: string;
 }
 
-export function useSongsFilter({ songs, userId, favoriteIds, viewedSongIds, sortBy }: UseSongsFilterOptions) {
+export function useSongsFilter({ songs, userId, favoriteIds, userRecordingCompositionIds = new Set(), viewedSongIds, sortBy }: UseSongsFilterOptions) {
   const defaultState: SongFilterState = {
     status: userId ? 'all' : 'public',
     search: '',
@@ -21,6 +22,7 @@ export function useSongsFilter({ songs, userId, favoriteIds, viewedSongIds, sort
     tags: [],
     chords: false,
     melody: false,
+    myRecordings: false,
     favorites: false,
     mine: false,
     new: false,
@@ -39,6 +41,7 @@ export function useSongsFilter({ songs, userId, favoriteIds, viewedSongIds, sort
         search: params.get('search') || '',
         chords: params.get('chords') === 'true',
         melody: params.get('melody') === 'true',
+        myRecordings: params.get('myRecordings') === 'true',
         favorites: params.get('favorites') === 'true',
         mine: params.get('mine') === 'true',
         new: params.get('new') === 'true',
@@ -51,6 +54,7 @@ export function useSongsFilter({ songs, userId, favoriteIds, viewedSongIds, sort
         search: state.search || '',
         chords: state.chords ? 'true' : '',
         melody: state.melody ? 'true' : '',
+        myRecordings: state.myRecordings ? 'true' : '',
         favorites: state.favorites ? 'true' : '',
         mine: state.mine ? 'true' : '',
         new: state.new ? 'true' : '',
@@ -60,11 +64,12 @@ export function useSongsFilter({ songs, userId, favoriteIds, viewedSongIds, sort
     }
   );
 
-  // Apply post-filters (favorites, mine, new)
+  // Apply post-filters (favorites, mine, myRecordings, new)
   const finalFilteredItems = useMemo(() => {
     let items = filteredItems;
     if (state.favorites) items = items.filter(s => favoriteIds.has(s.id));
     if (state.mine && userId) items = items.filter(s => s.ownerId === userId);
+    if (state.myRecordings && userId) items = items.filter(s => userRecordingCompositionIds.has(s.id));
     if (state.new) {
       // eslint-disable-next-line react-hooks/purity
       const cutoff = Date.now() - THIRTY_DAYS_MS;
@@ -73,7 +78,7 @@ export function useSongsFilter({ songs, userId, favoriteIds, viewedSongIds, sort
       );
     }
     return items;
-  }, [filteredItems, state.favorites, state.mine, state.new, favoriteIds, viewedSongIds, userId]);
+  }, [filteredItems, state.favorites, state.mine, state.myRecordings, state.new, favoriteIds, userRecordingCompositionIds, viewedSongIds, userId]);
 
   // Sort
   const displaySongs = useMemo(() => {

--- a/hooks/useToggleFavorite.ts
+++ b/hooks/useToggleFavorite.ts
@@ -50,6 +50,8 @@ export function useToggleFavorite(id: string, initialIsFavorite: boolean = false
             }
             // Invalidate the shared favorites cache so every consumer sees fresh data
             queryClient.invalidateQueries({ queryKey: SONG_KEYS.allFavorites() });
+            // Bust the global filter counts so the favoritesCount badge refreshes
+            queryClient.invalidateQueries({ queryKey: SONG_KEYS.globalFilterCounts() });
         }
     };
 

--- a/lib/actions/rehearsal.ts
+++ b/lib/actions/rehearsal.ts
@@ -66,13 +66,13 @@ export async function uploadRehearsalRecording(
   songVersionId: string,
   name: string,
   blob: Blob
-): Promise<UserRecording | null> {
+): Promise<{ recording: UserRecording | null; error: string | null }> {
   const supabase = createClient();
   const { data: { user }, error: authError } = await supabase.auth.getUser();
 
   if (authError || !user) {
     console.error("[rehearsal] User not logged in, cannot upload recording");
-    return null;
+    return { recording: null, error: "User not logged in. Please sign in again." };
   }
 
   const fileId = typeof window !== 'undefined' && window.crypto?.randomUUID 
@@ -112,7 +112,7 @@ export async function uploadRehearsalRecording(
 
   if (uploadError) {
     console.error("[rehearsal] Error uploading audio file to storage:", uploadError);
-    return null;
+    return { recording: null, error: uploadError.message || "Failed to upload file to storage bucket." };
   }
 
   // Insert database metadata row
@@ -131,7 +131,7 @@ export async function uploadRehearsalRecording(
     console.error("[rehearsal] Error inserting recording metadata:", dbError);
     // Attempt cleanup of orphaned storage file
     await supabase.storage.from("rehearsals").remove([storagePath]);
-    return null;
+    return { recording: null, error: dbError.message || "Failed to save recording metadata." };
   }
 
   // Generate signed URL for return value
@@ -140,8 +140,11 @@ export async function uploadRehearsalRecording(
     .createSignedUrl(storagePath, 3600);
 
   return {
-    ...(data as UserRecording),
-    audioUrl: signedData?.signedUrl,
+    recording: {
+      ...(data as UserRecording),
+      audioUrl: signedData?.signedUrl,
+    },
+    error: null,
   };
 }
 

--- a/lib/actions/rehearsal.ts
+++ b/lib/actions/rehearsal.ts
@@ -84,9 +84,19 @@ export async function uploadRehearsalRecording(
     const mainType = blob.type.split(";")[0];
     const subType = mainType.split("/")[1];
     if (subType) {
-      if (subType === "mpeg") rawExt = "mp3";
-      else if (subType === "x-m4a" || subType === "mp4") rawExt = "m4a";
+      if (subType === "mpeg" || subType === "mp3") rawExt = "mp3";
+      else if (subType === "x-m4a" || subType === "mp4" || subType === "m4a") rawExt = "m4a";
+      else if (subType === "opus") rawExt = "opus";
+      else if (subType === "flac" || subType === "x-flac") rawExt = "flac";
+      else if (subType === "ogg" || subType === "vorbis") rawExt = "ogg";
       else rawExt = subType;
+    }
+  }
+  // Check if blob is a File instance with name extension
+  if ('name' in blob && (blob as File).name.includes('.')) {
+    const nameExt = (blob as File).name.split('.').pop()?.toLowerCase();
+    if (nameExt && ['mp3', 'm4a', 'opus', 'flac', 'wav', 'ogg', 'webm', 'aac'].includes(nameExt)) {
+      rawExt = nameExt;
     }
   }
   const storagePath = `${user.id}/${songVersionId}/${fileId}.${rawExt}`;

--- a/lib/actions/rehearsal.ts
+++ b/lib/actions/rehearsal.ts
@@ -79,8 +79,17 @@ export async function uploadRehearsalRecording(
     ? window.crypto.randomUUID() 
     : Math.random().toString(36).substring(2) + Date.now().toString(36);
 
-  const fileExt = blob.type.split(";")[0].split("/")[1] || "webm";
-  const storagePath = `${user.id}/${songVersionId}/${fileId}.${fileExt}`;
+  let rawExt = "webm";
+  if (blob.type) {
+    const mainType = blob.type.split(";")[0];
+    const subType = mainType.split("/")[1];
+    if (subType) {
+      if (subType === "mpeg") rawExt = "mp3";
+      else if (subType === "x-m4a" || subType === "mp4") rawExt = "m4a";
+      else rawExt = subType;
+    }
+  }
+  const storagePath = `${user.id}/${songVersionId}/${fileId}.${rawExt}`;
 
   // Upload blob to Supabase storage rehearsals bucket
   const { error: uploadError } = await supabase.storage

--- a/lib/actions/rehearsal.ts
+++ b/lib/actions/rehearsal.ts
@@ -6,6 +6,7 @@ export interface UserRecording {
   song_version_id: string;
   recording_name: string;
   storage_path: string;
+  position?: number;
   created_at: string;
   audioUrl?: string; // Resolved temporary signed URL or public URL
 }
@@ -25,6 +26,7 @@ export async function getUserRecordings(songVersionId: string): Promise<UserReco
     .select("*")
     .eq("song_version_id", songVersionId)
     .eq("user_id", user.id)
+    .order("position", { ascending: true })
     .order("created_at", { ascending: false });
 
   if (error) {
@@ -177,4 +179,34 @@ export async function deleteUserRecording(
   }
 
   return true;
+}
+
+// 4. Reorder user recordings
+export async function reorderUserRecordings(
+  orderedRecordingIds: string[]
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: "Not authenticated" };
+  }
+
+  const updates = orderedRecordingIds.map((id, index) =>
+    supabase
+      .from("user_recordings")
+      .update({ position: index })
+      .eq("id", id)
+      .eq("user_id", user.id)
+  );
+
+  const results = await Promise.all(updates);
+  const hasError = results.some((r) => r.error);
+
+  if (hasError) {
+    console.error("[rehearsal] Error updating recording positions:", results.find((r) => r.error)?.error);
+    return { success: false, error: "Failed to update order" };
+  }
+
+  return { success: true };
 }

--- a/lib/playlists/smartPlaylists.ts
+++ b/lib/playlists/smartPlaylists.ts
@@ -1,5 +1,6 @@
-export const SMART_PLAYLISTS = ['My Favorites', 'My Songs', 'My Drafts'] as const;
+export const SMART_PLAYLISTS = ['My Favorites', 'My Songs', 'My Drafts', 'My Recordings'] as const;
 
 export function isSmartPlaylist(title: string): boolean {
     return (SMART_PLAYLISTS as readonly string[]).includes(title);
 }
+

--- a/lib/songs/filterConfig.ts
+++ b/lib/songs/filterConfig.ts
@@ -8,6 +8,7 @@ export interface SongFilterState {
   tags?: string[];        // AND Logic
   chords?: boolean;
   melody?: boolean;
+  myRecordings?: boolean;
   search?: string;
   status: 'all' | 'public' | 'draft';
   favorites?: boolean;
@@ -29,6 +30,7 @@ export function isDraftActive(draft: SongFilterState, userId?: string): boolean 
     (userId && draft.status !== 'all') ||
     draft.chords ||
     draft.melody ||
+    draft.myRecordings ||
     draft.favorites ||
     draft.mine ||
     draft.new ||

--- a/lib/songs/queryKeys.ts
+++ b/lib/songs/queryKeys.ts
@@ -26,6 +26,9 @@ export const SONG_KEYS = {
 
     /** Taxonomy / category tree */
     taxonomy: () => ['taxonomy'] as const,
+
+    /** Global filter counts (chords, melody, mine, favorites) used in GlobalSearchModal */
+    globalFilterCounts: (userId?: string) => ['global-filter-counts', userId] as const,
 } as const;
 
 /**

--- a/supabase/migrations/20260629152000_private_rehearsals.sql
+++ b/supabase/migrations/20260629152000_private_rehearsals.sql
@@ -47,11 +47,17 @@ CREATE TABLE IF NOT EXISTS public.user_recordings (
     song_version_id UUID NOT NULL REFERENCES public.song_versions(id) ON DELETE CASCADE,
     recording_name TEXT NOT NULL,
     storage_path TEXT NOT NULL UNIQUE,
+    position INT NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Enable RLS on public.user_recordings
 ALTER TABLE public.user_recordings ENABLE ROW LEVEL SECURITY;
+
+-- Allow authenticated users to update their own recording metadata
+DROP POLICY IF EXISTS "Allow users to update their own recordings" ON public.user_recordings;
+CREATE POLICY "Allow users to update their own recordings" ON public.user_recordings FOR
+UPDATE TO authenticated USING (auth.uid() = user_id);
 
 -- Allow authenticated users to select/read their own recording metadata
 DROP POLICY IF EXISTS "Allow users to read their own recordings" ON public.user_recordings;

--- a/supabase/migrations/20260629152000_private_rehearsals.sql
+++ b/supabase/migrations/20260629152000_private_rehearsals.sql
@@ -3,8 +3,9 @@
 
 -- 1. Storage Setup for Private Rehearsals
 -- Create rehearsals bucket (public = false)
-INSERT INTO storage.buckets (id, name, public)
-VALUES ('rehearsals', 'rehearsals', false) ON CONFLICT (id) DO NOTHING;
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('rehearsals', 'rehearsals', false, 52428800, NULL)
+ON CONFLICT (id) DO UPDATE SET file_size_limit = EXCLUDED.file_size_limit, allowed_mime_types = EXCLUDED.allowed_mime_types;
 
 -- Allow authenticated users to upload (insert) files to rehearsals inside their own folder
 DROP POLICY IF EXISTS "Allow authenticated users to upload rehearsals" ON storage.objects;

--- a/supabase/seeds/09_artist_distribution.sql
+++ b/supabase/seeds/09_artist_distribution.sql
@@ -1,0 +1,21 @@
+-- Seed extension: Distribute diverse medicine music artists across compositions
+WITH target_songs AS (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY title) as rn
+  FROM public.compositions
+  WHERE original_author = 'Traditional' OR original_author IS NULL
+)
+UPDATE public.compositions c
+SET original_author = CASE (ts.rn % 10)
+  WHEN 1 THEN 'Peia'
+  WHEN 2 THEN 'Curawaka'
+  WHEN 3 THEN 'Ayla Nereo'
+  WHEN 4 THEN 'Danit'
+  WHEN 5 THEN 'Shimshai'
+  WHEN 6 THEN 'Alain Merens'
+  WHEN 7 THEN 'Nico Pérez'
+  WHEN 8 THEN 'Xavier Rudd'
+  WHEN 9 THEN 'Fiona Helmer'
+  ELSE 'Traditional'
+END
+FROM target_songs ts
+WHERE c.id = ts.id;

--- a/supabase/seeds/10_personal_recordings.sql
+++ b/supabase/seeds/10_personal_recordings.sql
@@ -1,0 +1,131 @@
+-- Seed: Personal Rehearsal Recordings
+-- Assigns 1–3 dummy recordings to 30 songs for the admin dev user.
+-- User: roel.de.meester+admin@gmail.com (a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11)
+-- Storage paths are fake — they represent paths in the 'rehearsals' bucket.
+-- Recordings are scoped per user_id + song_version_id per the RLS policy.
+
+-- Clean up any previous seed recordings for this user to allow re-seeding
+DELETE FROM public.user_recordings
+WHERE user_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+INSERT INTO public.user_recordings (id, user_id, song_version_id, recording_name, storage_path, created_at) VALUES
+
+-- Colibri (1 recording)
+('11000000-0000-0000-0000-000000000001', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '84a0c04a-c9aa-4a3f-a4a2-b5c1e85433c4', 'Colibri – Morning Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/84a0c04a-c9aa-4a3f-a4a2-b5c1e85433c4/rec-001.webm', now() - interval '3 days'),
+
+-- Elevo mi canto (2 recordings)
+('11000000-0000-0000-0000-000000000002', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e929d554-5044-4d4d-991f-8b6a2068dc9c', 'Elevo mi canto – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e929d554-5044-4d4d-991f-8b6a2068dc9c/rec-001.webm', now() - interval '5 days'),
+('11000000-0000-0000-0000-000000000003', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e929d554-5044-4d4d-991f-8b6a2068dc9c', 'Elevo mi canto – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e929d554-5044-4d4d-991f-8b6a2068dc9c/rec-002.webm', now() - interval '4 days'),
+
+-- Ayaruna (3 recordings)
+('11000000-0000-0000-0000-000000000004', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0f4c150c-e802-4057-832d-f047a2aa1dba', 'Ayaruna – Slow Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0f4c150c-e802-4057-832d-f047a2aa1dba/rec-001.webm', now() - interval '7 days'),
+('11000000-0000-0000-0000-000000000005', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0f4c150c-e802-4057-832d-f047a2aa1dba', 'Ayaruna – Full Speed', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0f4c150c-e802-4057-832d-f047a2aa1dba/rec-002.webm', now() - interval '6 days'),
+('11000000-0000-0000-0000-000000000006', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0f4c150c-e802-4057-832d-f047a2aa1dba', 'Ayaruna – Final Take', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0f4c150c-e802-4057-832d-f047a2aa1dba/rec-003.webm', now() - interval '1 day'),
+
+-- Churubia (1 recording)
+('11000000-0000-0000-0000-000000000007', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '5b150de6-2cc3-4f60-9224-5573bc7d2536', 'Churubia – Morning', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/5b150de6-2cc3-4f60-9224-5573bc7d2536/rec-001.webm', now() - interval '2 days'),
+
+-- Cura Santa Cura (2 recordings)
+('11000000-0000-0000-0000-000000000008', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '919311bf-c46b-4f7e-80a7-cbf7882e3f43', 'Cura Santa Cura – Attempt 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/919311bf-c46b-4f7e-80a7-cbf7882e3f43/rec-001.webm', now() - interval '10 days'),
+('11000000-0000-0000-0000-000000000009', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '919311bf-c46b-4f7e-80a7-cbf7882e3f43', 'Cura Santa Cura – Attempt 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/919311bf-c46b-4f7e-80a7-cbf7882e3f43/rec-002.webm', now() - interval '8 days'),
+
+-- El Agua Cambia (1 recording)
+('11000000-0000-0000-0000-000000000010', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0041b6b0-d0c2-4c1c-9573-c474e120a50a', 'El Agua Cambia – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0041b6b0-d0c2-4c1c-9573-c474e120a50a/rec-001.webm', now() - interval '4 days'),
+
+-- Aguacollita profunda (3 recordings)
+('11000000-0000-0000-0000-000000000011', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'f88e55d9-4873-486c-b733-d391ae674829', 'Aguacollita – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/f88e55d9-4873-486c-b733-d391ae674829/rec-001.webm', now() - interval '14 days'),
+('11000000-0000-0000-0000-000000000012', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'f88e55d9-4873-486c-b733-d391ae674829', 'Aguacollita – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/f88e55d9-4873-486c-b733-d391ae674829/rec-002.webm', now() - interval '12 days'),
+('11000000-0000-0000-0000-000000000013', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'f88e55d9-4873-486c-b733-d391ae674829', 'Aguacollita – Best Take', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/f88e55d9-4873-486c-b733-d391ae674829/rec-003.webm', now() - interval '11 days'),
+
+-- Ayahuasca Cura (2 recordings)
+('11000000-0000-0000-0000-000000000014', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb', 'Ayahuasca Cura – Slow', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb/rec-001.webm', now() - interval '9 days'),
+('11000000-0000-0000-0000-000000000015', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb', 'Ayahuasca Cura – Full', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb/rec-002.webm', now() - interval '7 days'),
+
+-- Cura Do Beija-Flor (1 recording)
+('11000000-0000-0000-0000-000000000016', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a9bef500-70d7-41e1-ae9e-3e244eebc2cc', 'Beija-Flor – Morning', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a9bef500-70d7-41e1-ae9e-3e244eebc2cc/rec-001.webm', now() - interval '6 days'),
+
+-- Canta Pajarito (2 recordings)
+('11000000-0000-0000-0000-000000000017', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '2ea8b586-dcdc-4e3a-937a-9d233b4c8e10', 'Canta Pajarito – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/2ea8b586-dcdc-4e3a-937a-9d233b4c8e10/rec-001.webm', now() - interval '5 days'),
+('11000000-0000-0000-0000-000000000018', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '2ea8b586-dcdc-4e3a-937a-9d233b4c8e10', 'Canta Pajarito – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/2ea8b586-dcdc-4e3a-937a-9d233b4c8e10/rec-002.webm', now() - interval '3 days'),
+
+-- Corazón de Oro (3 recordings)
+('11000000-0000-0000-0000-000000000019', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a5be8148-fa90-4aa2-8c9d-d13c6d06542a', 'Corazon de Oro – Rough', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a5be8148-fa90-4aa2-8c9d-d13c6d06542a/rec-001.webm', now() - interval '20 days'),
+('11000000-0000-0000-0000-000000000020', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a5be8148-fa90-4aa2-8c9d-d13c6d06542a', 'Corazon de Oro – Better', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a5be8148-fa90-4aa2-8c9d-d13c6d06542a/rec-002.webm', now() - interval '15 days'),
+('11000000-0000-0000-0000-000000000021', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a5be8148-fa90-4aa2-8c9d-d13c6d06542a', 'Corazon de Oro – Final', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a5be8148-fa90-4aa2-8c9d-d13c6d06542a/rec-003.webm', now() - interval '2 days'),
+
+-- Cura Sana (1 recording)
+('11000000-0000-0000-0000-000000000022', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'dc32c57a-092d-498a-9fa8-2582d228e349', 'Cura Sana – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/dc32c57a-092d-498a-9fa8-2582d228e349/rec-001.webm', now() - interval '8 days'),
+
+-- Defuma defumador (2 recordings)
+('11000000-0000-0000-0000-000000000023', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '790de57d-eb0e-4c38-ab3f-cdbc614ce8b4', 'Defuma – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/790de57d-eb0e-4c38-ab3f-cdbc614ce8b4/rec-001.webm', now() - interval '3 days'),
+('11000000-0000-0000-0000-000000000024', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '790de57d-eb0e-4c38-ab3f-cdbc614ce8b4', 'Defuma – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/790de57d-eb0e-4c38-ab3f-cdbc614ce8b4/rec-002.webm', now() - interval '1 day'),
+
+-- Eh Madre Madrecita (1 recording)
+('11000000-0000-0000-0000-000000000025', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '195d0325-619f-4e7d-aa41-e9a4a0820aeb', 'Eh Madre – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/195d0325-619f-4e7d-aa41-e9a4a0820aeb/rec-001.webm', now() - interval '6 days'),
+
+-- Abuelito Abuelita (3 recordings)
+('11000000-0000-0000-0000-000000000026', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '1a13f493-8a7a-417f-89a4-a385cb555ab3', 'Abuelito – Slow', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/1a13f493-8a7a-417f-89a4-a385cb555ab3/rec-001.webm', now() - interval '16 days'),
+('11000000-0000-0000-0000-000000000027', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '1a13f493-8a7a-417f-89a4-a385cb555ab3', 'Abuelito – Medium', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/1a13f493-8a7a-417f-89a4-a385cb555ab3/rec-002.webm', now() - interval '10 days'),
+('11000000-0000-0000-0000-000000000028', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '1a13f493-8a7a-417f-89a4-a385cb555ab3', 'Abuelito – Final', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/1a13f493-8a7a-417f-89a4-a385cb555ab3/rec-003.webm', now() - interval '5 days'),
+
+-- Agua transparente (2 recordings)
+('11000000-0000-0000-0000-000000000029', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '11835c30-bcf1-4d46-8f44-183b36ffb53f', 'Agua transparente – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/11835c30-bcf1-4d46-8f44-183b36ffb53f/rec-001.webm', now() - interval '4 days'),
+('11000000-0000-0000-0000-000000000030', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '11835c30-bcf1-4d46-8f44-183b36ffb53f', 'Agua transparente – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/11835c30-bcf1-4d46-8f44-183b36ffb53f/rec-002.webm', now() - interval '2 days'),
+
+-- Amo Amo Amo (1 recording)
+('11000000-0000-0000-0000-000000000031', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd922900c-b0fe-44bb-831d-1b67534ada5e', 'Amo Amo – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d922900c-b0fe-44bb-831d-1b67534ada5e/rec-001.webm', now() - interval '11 days'),
+
+-- Aqui en la montaña (2 recordings)
+('11000000-0000-0000-0000-000000000032', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'b86a70f7-8d97-4fa9-af02-7745bc70f83c', 'Montaña – Morning', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/b86a70f7-8d97-4fa9-af02-7745bc70f83c/rec-001.webm', now() - interval '9 days'),
+('11000000-0000-0000-0000-000000000033', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'b86a70f7-8d97-4fa9-af02-7745bc70f83c', 'Montaña – Evening', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/b86a70f7-8d97-4fa9-af02-7745bc70f83c/rec-002.webm', now() - interval '7 days'),
+
+-- Belleza Pura (1 recording)
+('11000000-0000-0000-0000-000000000034', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '63421d7f-f73c-446f-8a22-c5e52e937e7f', 'Belleza Pura – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/63421d7f-f73c-446f-8a22-c5e52e937e7f/rec-001.webm', now() - interval '5 days'),
+
+-- Bendice (3 recordings)
+('11000000-0000-0000-0000-000000000035', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '8ba28762-a7ae-40e9-b147-4332037c8691', 'Bendice – Rough', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/8ba28762-a7ae-40e9-b147-4332037c8691/rec-001.webm', now() - interval '18 days'),
+('11000000-0000-0000-0000-000000000036', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '8ba28762-a7ae-40e9-b147-4332037c8691', 'Bendice – Polished', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/8ba28762-a7ae-40e9-b147-4332037c8691/rec-002.webm', now() - interval '13 days'),
+('11000000-0000-0000-0000-000000000037', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '8ba28762-a7ae-40e9-b147-4332037c8691', 'Bendice – Performance', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/8ba28762-a7ae-40e9-b147-4332037c8691/rec-003.webm', now() - interval '1 day'),
+
+-- Brilla un Colibri (1 recording)
+('11000000-0000-0000-0000-000000000038', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '21033658-4720-4193-ab50-9675d064d667', 'Brilla Colibri – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/21033658-4720-4193-ab50-9675d064d667/rec-001.webm', now() - interval '4 days'),
+
+-- Caboclo Curador (2 recordings)
+('11000000-0000-0000-0000-000000000039', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a028632e-e865-410b-9f55-879018c96f9a', 'Caboclo – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a028632e-e865-410b-9f55-879018c96f9a/rec-001.webm', now() - interval '3 days'),
+('11000000-0000-0000-0000-000000000040', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a028632e-e865-410b-9f55-879018c96f9a', 'Caboclo – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a028632e-e865-410b-9f55-879018c96f9a/rec-002.webm', now() - interval '1 day'),
+
+-- Como no voy a cantar (1 recording)
+('11000000-0000-0000-0000-000000000041', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '6e5484fe-b08c-4c8f-a75a-deba5604441e', 'Como no voy – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/6e5484fe-b08c-4c8f-a75a-deba5604441e/rec-001.webm', now() - interval '6 days'),
+
+-- Danza del sol (3 recordings)
+('11000000-0000-0000-0000-000000000042', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e5449b97-4aec-45ba-970a-445387d2e8ab', 'Danza del sol – Dawn', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e5449b97-4aec-45ba-970a-445387d2e8ab/rec-001.webm', now() - interval '21 days'),
+('11000000-0000-0000-0000-000000000043', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e5449b97-4aec-45ba-970a-445387d2e8ab', 'Danza del sol – Noon', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e5449b97-4aec-45ba-970a-445387d2e8ab/rec-002.webm', now() - interval '14 days'),
+('11000000-0000-0000-0000-000000000044', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e5449b97-4aec-45ba-970a-445387d2e8ab', 'Danza del sol – Full', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e5449b97-4aec-45ba-970a-445387d2e8ab/rec-003.webm', now() - interval '3 days'),
+
+-- Defuma Con As Ervas Da Jurema (2 recordings)
+('11000000-0000-0000-0000-000000000045', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '31a12b76-5851-4651-9536-e7db2f76d785', 'Jurema – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/31a12b76-5851-4651-9536-e7db2f76d785/rec-001.webm', now() - interval '8 days'),
+('11000000-0000-0000-0000-000000000046', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '31a12b76-5851-4651-9536-e7db2f76d785', 'Jurema – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/31a12b76-5851-4651-9536-e7db2f76d785/rec-002.webm', now() - interval '5 days'),
+
+-- Defuma esta casa (1 recording)
+('11000000-0000-0000-0000-000000000047', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '747aded6-4c50-4816-a748-62389ed7c408', 'Defuma esta casa – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/747aded6-4c50-4816-a748-62389ed7c408/rec-001.webm', now() - interval '2 days'),
+
+-- Desde los Andes (2 recordings)
+('11000000-0000-0000-0000-000000000048', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'aa2e58fe-447b-470c-a763-8b4bd9abc9aa', 'Andes – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/aa2e58fe-447b-470c-a763-8b4bd9abc9aa/rec-001.webm', now() - interval '7 days'),
+('11000000-0000-0000-0000-000000000049', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'aa2e58fe-447b-470c-a763-8b4bd9abc9aa', 'Andes – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/aa2e58fe-447b-470c-a763-8b4bd9abc9aa/rec-002.webm', now() - interval '4 days'),
+
+-- Agua De Estrellas (1 recording)
+('11000000-0000-0000-0000-000000000050', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'c4e141dd-9179-49d4-b249-bfcf5453bc21', 'Estrellas – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/c4e141dd-9179-49d4-b249-bfcf5453bc21/rec-001.webm', now() - interval '9 days'),
+
+-- Agua de vida lluvia (3 recordings)
+('11000000-0000-0000-0000-000000000051', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd42ded1c-4af9-4ee2-97bf-9a6bcc521ce6', 'Lluvia – Rough', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d42ded1c-4af9-4ee2-97bf-9a6bcc521ce6/rec-001.webm', now() - interval '25 days'),
+('11000000-0000-0000-0000-000000000052', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd42ded1c-4af9-4ee2-97bf-9a6bcc521ce6', 'Lluvia – Refined', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d42ded1c-4af9-4ee2-97bf-9a6bcc521ce6/rec-002.webm', now() - interval '18 days'),
+('11000000-0000-0000-0000-000000000053', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd42ded1c-4af9-4ee2-97bf-9a6bcc521ce6', 'Lluvia – Final', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d42ded1c-4af9-4ee2-97bf-9a6bcc521ce6/rec-003.webm', now() - interval '2 days'),
+
+-- Aguila Moteada (2 recordings)
+('11000000-0000-0000-0000-000000000054', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '87a15792-b298-48ad-a59a-fdab36958e08', 'Aguila – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/87a15792-b298-48ad-a59a-fdab36958e08/rec-001.webm', now() - interval '12 days'),
+('11000000-0000-0000-0000-000000000055', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '87a15792-b298-48ad-a59a-fdab36958e08', 'Aguila – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/87a15792-b298-48ad-a59a-fdab36958e08/rec-002.webm', now() - interval '10 days'),
+
+-- En el camino (1 recording)
+('11000000-0000-0000-0000-000000000056', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '47efd643-eaea-4459-b8f8-7f64a0c8d02a', 'En el camino – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/47efd643-eaea-4459-b8f8-7f64a0c8d02a/rec-001.webm', now() - interval '3 days')
+
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/seeds/10_personal_recordings.sql
+++ b/supabase/seeds/10_personal_recordings.sql
@@ -1,131 +1,53 @@
 -- Seed: Personal Rehearsal Recordings
--- Assigns 1–3 dummy recordings to 30 songs for the admin dev user.
--- User: roel.de.meester+admin@gmail.com (a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11)
--- Storage paths are fake — they represent paths in the 'rehearsals' bucket.
--- Recordings are scoped per user_id + song_version_id per the RLS policy.
+-- Seed 30 private rehearsal recordings for Admin user and 30 for Member user dynamically.
+-- Resolves valid song_version_id references directly from public.song_versions.
 
--- Clean up any previous seed recordings for this user to allow re-seeding
-DELETE FROM public.user_recordings
-WHERE user_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+DO $$
+DECLARE
+  v_admin_id uuid := 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+  v_member_id uuid := 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13';
+  r RECORD;
+  i INT := 1;
+  v_user_id uuid;
+  v_uuid uuid;
+  v_storage_path text;
+  v_name text;
+BEGIN
+  -- Clean up previous user_recordings
+  DELETE FROM public.user_recordings;
 
-INSERT INTO public.user_recordings (id, user_id, song_version_id, recording_name, storage_path, created_at) VALUES
+  FOR r IN (
+    SELECT sv.id AS version_id, c.title
+    FROM public.song_versions sv
+    JOIN public.compositions c ON sv.composition_id = c.id
+    ORDER BY c.title ASC
+  ) LOOP
+    -- Exit once we have created 60 recordings total (30 for Admin, 30 for Member)
+    EXIT WHEN i > 60;
 
--- Colibri (1 recording)
-('11000000-0000-0000-0000-000000000001', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '84a0c04a-c9aa-4a3f-a4a2-b5c1e85433c4', 'Colibri – Morning Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/84a0c04a-c9aa-4a3f-a4a2-b5c1e85433c4/rec-001.webm', now() - interval '3 days'),
+    IF i <= 30 THEN
+      v_user_id := v_admin_id;
+      v_name := r.title || ' – Rehearsal Take ' || (((i - 1) % 3) + 1);
+    ELSE
+      v_user_id := v_member_id;
+      v_name := r.title || ' – Member Rehearsal ' || (((i - 31) % 3) + 1);
+    END IF;
 
--- Elevo mi canto (2 recordings)
-('11000000-0000-0000-0000-000000000002', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e929d554-5044-4d4d-991f-8b6a2068dc9c', 'Elevo mi canto – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e929d554-5044-4d4d-991f-8b6a2068dc9c/rec-001.webm', now() - interval '5 days'),
-('11000000-0000-0000-0000-000000000003', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e929d554-5044-4d4d-991f-8b6a2068dc9c', 'Elevo mi canto – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e929d554-5044-4d4d-991f-8b6a2068dc9c/rec-002.webm', now() - interval '4 days'),
+    v_uuid := ('11000000-0000-0000-0000-' || lpad(i::text, 12, '0'))::uuid;
+    v_storage_path := v_user_id::text || '/' || r.version_id::text || '/rec-' || lpad(i::text, 3, '0') || '.webm';
 
--- Ayaruna (3 recordings)
-('11000000-0000-0000-0000-000000000004', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0f4c150c-e802-4057-832d-f047a2aa1dba', 'Ayaruna – Slow Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0f4c150c-e802-4057-832d-f047a2aa1dba/rec-001.webm', now() - interval '7 days'),
-('11000000-0000-0000-0000-000000000005', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0f4c150c-e802-4057-832d-f047a2aa1dba', 'Ayaruna – Full Speed', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0f4c150c-e802-4057-832d-f047a2aa1dba/rec-002.webm', now() - interval '6 days'),
-('11000000-0000-0000-0000-000000000006', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0f4c150c-e802-4057-832d-f047a2aa1dba', 'Ayaruna – Final Take', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0f4c150c-e802-4057-832d-f047a2aa1dba/rec-003.webm', now() - interval '1 day'),
+    INSERT INTO public.user_recordings (id, user_id, song_version_id, recording_name, storage_path, created_at)
+    VALUES (
+      v_uuid,
+      v_user_id,
+      r.version_id,
+      v_name,
+      v_storage_path,
+      now() - ( (61 - i) || ' hours' )::interval
+    );
 
--- Churubia (1 recording)
-('11000000-0000-0000-0000-000000000007', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '5b150de6-2cc3-4f60-9224-5573bc7d2536', 'Churubia – Morning', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/5b150de6-2cc3-4f60-9224-5573bc7d2536/rec-001.webm', now() - interval '2 days'),
+    i := i + 1;
+  END LOOP;
 
--- Cura Santa Cura (2 recordings)
-('11000000-0000-0000-0000-000000000008', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '919311bf-c46b-4f7e-80a7-cbf7882e3f43', 'Cura Santa Cura – Attempt 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/919311bf-c46b-4f7e-80a7-cbf7882e3f43/rec-001.webm', now() - interval '10 days'),
-('11000000-0000-0000-0000-000000000009', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '919311bf-c46b-4f7e-80a7-cbf7882e3f43', 'Cura Santa Cura – Attempt 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/919311bf-c46b-4f7e-80a7-cbf7882e3f43/rec-002.webm', now() - interval '8 days'),
-
--- El Agua Cambia (1 recording)
-('11000000-0000-0000-0000-000000000010', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '0041b6b0-d0c2-4c1c-9573-c474e120a50a', 'El Agua Cambia – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/0041b6b0-d0c2-4c1c-9573-c474e120a50a/rec-001.webm', now() - interval '4 days'),
-
--- Aguacollita profunda (3 recordings)
-('11000000-0000-0000-0000-000000000011', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'f88e55d9-4873-486c-b733-d391ae674829', 'Aguacollita – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/f88e55d9-4873-486c-b733-d391ae674829/rec-001.webm', now() - interval '14 days'),
-('11000000-0000-0000-0000-000000000012', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'f88e55d9-4873-486c-b733-d391ae674829', 'Aguacollita – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/f88e55d9-4873-486c-b733-d391ae674829/rec-002.webm', now() - interval '12 days'),
-('11000000-0000-0000-0000-000000000013', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'f88e55d9-4873-486c-b733-d391ae674829', 'Aguacollita – Best Take', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/f88e55d9-4873-486c-b733-d391ae674829/rec-003.webm', now() - interval '11 days'),
-
--- Ayahuasca Cura (2 recordings)
-('11000000-0000-0000-0000-000000000014', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb', 'Ayahuasca Cura – Slow', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb/rec-001.webm', now() - interval '9 days'),
-('11000000-0000-0000-0000-000000000015', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb', 'Ayahuasca Cura – Full', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/9bcd5fb5-79e3-460f-ae3b-d9afeddf83cb/rec-002.webm', now() - interval '7 days'),
-
--- Cura Do Beija-Flor (1 recording)
-('11000000-0000-0000-0000-000000000016', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a9bef500-70d7-41e1-ae9e-3e244eebc2cc', 'Beija-Flor – Morning', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a9bef500-70d7-41e1-ae9e-3e244eebc2cc/rec-001.webm', now() - interval '6 days'),
-
--- Canta Pajarito (2 recordings)
-('11000000-0000-0000-0000-000000000017', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '2ea8b586-dcdc-4e3a-937a-9d233b4c8e10', 'Canta Pajarito – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/2ea8b586-dcdc-4e3a-937a-9d233b4c8e10/rec-001.webm', now() - interval '5 days'),
-('11000000-0000-0000-0000-000000000018', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '2ea8b586-dcdc-4e3a-937a-9d233b4c8e10', 'Canta Pajarito – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/2ea8b586-dcdc-4e3a-937a-9d233b4c8e10/rec-002.webm', now() - interval '3 days'),
-
--- Corazón de Oro (3 recordings)
-('11000000-0000-0000-0000-000000000019', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a5be8148-fa90-4aa2-8c9d-d13c6d06542a', 'Corazon de Oro – Rough', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a5be8148-fa90-4aa2-8c9d-d13c6d06542a/rec-001.webm', now() - interval '20 days'),
-('11000000-0000-0000-0000-000000000020', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a5be8148-fa90-4aa2-8c9d-d13c6d06542a', 'Corazon de Oro – Better', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a5be8148-fa90-4aa2-8c9d-d13c6d06542a/rec-002.webm', now() - interval '15 days'),
-('11000000-0000-0000-0000-000000000021', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a5be8148-fa90-4aa2-8c9d-d13c6d06542a', 'Corazon de Oro – Final', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a5be8148-fa90-4aa2-8c9d-d13c6d06542a/rec-003.webm', now() - interval '2 days'),
-
--- Cura Sana (1 recording)
-('11000000-0000-0000-0000-000000000022', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'dc32c57a-092d-498a-9fa8-2582d228e349', 'Cura Sana – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/dc32c57a-092d-498a-9fa8-2582d228e349/rec-001.webm', now() - interval '8 days'),
-
--- Defuma defumador (2 recordings)
-('11000000-0000-0000-0000-000000000023', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '790de57d-eb0e-4c38-ab3f-cdbc614ce8b4', 'Defuma – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/790de57d-eb0e-4c38-ab3f-cdbc614ce8b4/rec-001.webm', now() - interval '3 days'),
-('11000000-0000-0000-0000-000000000024', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '790de57d-eb0e-4c38-ab3f-cdbc614ce8b4', 'Defuma – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/790de57d-eb0e-4c38-ab3f-cdbc614ce8b4/rec-002.webm', now() - interval '1 day'),
-
--- Eh Madre Madrecita (1 recording)
-('11000000-0000-0000-0000-000000000025', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '195d0325-619f-4e7d-aa41-e9a4a0820aeb', 'Eh Madre – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/195d0325-619f-4e7d-aa41-e9a4a0820aeb/rec-001.webm', now() - interval '6 days'),
-
--- Abuelito Abuelita (3 recordings)
-('11000000-0000-0000-0000-000000000026', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '1a13f493-8a7a-417f-89a4-a385cb555ab3', 'Abuelito – Slow', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/1a13f493-8a7a-417f-89a4-a385cb555ab3/rec-001.webm', now() - interval '16 days'),
-('11000000-0000-0000-0000-000000000027', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '1a13f493-8a7a-417f-89a4-a385cb555ab3', 'Abuelito – Medium', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/1a13f493-8a7a-417f-89a4-a385cb555ab3/rec-002.webm', now() - interval '10 days'),
-('11000000-0000-0000-0000-000000000028', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '1a13f493-8a7a-417f-89a4-a385cb555ab3', 'Abuelito – Final', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/1a13f493-8a7a-417f-89a4-a385cb555ab3/rec-003.webm', now() - interval '5 days'),
-
--- Agua transparente (2 recordings)
-('11000000-0000-0000-0000-000000000029', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '11835c30-bcf1-4d46-8f44-183b36ffb53f', 'Agua transparente – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/11835c30-bcf1-4d46-8f44-183b36ffb53f/rec-001.webm', now() - interval '4 days'),
-('11000000-0000-0000-0000-000000000030', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '11835c30-bcf1-4d46-8f44-183b36ffb53f', 'Agua transparente – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/11835c30-bcf1-4d46-8f44-183b36ffb53f/rec-002.webm', now() - interval '2 days'),
-
--- Amo Amo Amo (1 recording)
-('11000000-0000-0000-0000-000000000031', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd922900c-b0fe-44bb-831d-1b67534ada5e', 'Amo Amo – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d922900c-b0fe-44bb-831d-1b67534ada5e/rec-001.webm', now() - interval '11 days'),
-
--- Aqui en la montaña (2 recordings)
-('11000000-0000-0000-0000-000000000032', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'b86a70f7-8d97-4fa9-af02-7745bc70f83c', 'Montaña – Morning', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/b86a70f7-8d97-4fa9-af02-7745bc70f83c/rec-001.webm', now() - interval '9 days'),
-('11000000-0000-0000-0000-000000000033', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'b86a70f7-8d97-4fa9-af02-7745bc70f83c', 'Montaña – Evening', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/b86a70f7-8d97-4fa9-af02-7745bc70f83c/rec-002.webm', now() - interval '7 days'),
-
--- Belleza Pura (1 recording)
-('11000000-0000-0000-0000-000000000034', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '63421d7f-f73c-446f-8a22-c5e52e937e7f', 'Belleza Pura – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/63421d7f-f73c-446f-8a22-c5e52e937e7f/rec-001.webm', now() - interval '5 days'),
-
--- Bendice (3 recordings)
-('11000000-0000-0000-0000-000000000035', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '8ba28762-a7ae-40e9-b147-4332037c8691', 'Bendice – Rough', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/8ba28762-a7ae-40e9-b147-4332037c8691/rec-001.webm', now() - interval '18 days'),
-('11000000-0000-0000-0000-000000000036', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '8ba28762-a7ae-40e9-b147-4332037c8691', 'Bendice – Polished', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/8ba28762-a7ae-40e9-b147-4332037c8691/rec-002.webm', now() - interval '13 days'),
-('11000000-0000-0000-0000-000000000037', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '8ba28762-a7ae-40e9-b147-4332037c8691', 'Bendice – Performance', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/8ba28762-a7ae-40e9-b147-4332037c8691/rec-003.webm', now() - interval '1 day'),
-
--- Brilla un Colibri (1 recording)
-('11000000-0000-0000-0000-000000000038', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '21033658-4720-4193-ab50-9675d064d667', 'Brilla Colibri – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/21033658-4720-4193-ab50-9675d064d667/rec-001.webm', now() - interval '4 days'),
-
--- Caboclo Curador (2 recordings)
-('11000000-0000-0000-0000-000000000039', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a028632e-e865-410b-9f55-879018c96f9a', 'Caboclo – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a028632e-e865-410b-9f55-879018c96f9a/rec-001.webm', now() - interval '3 days'),
-('11000000-0000-0000-0000-000000000040', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a028632e-e865-410b-9f55-879018c96f9a', 'Caboclo – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/a028632e-e865-410b-9f55-879018c96f9a/rec-002.webm', now() - interval '1 day'),
-
--- Como no voy a cantar (1 recording)
-('11000000-0000-0000-0000-000000000041', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '6e5484fe-b08c-4c8f-a75a-deba5604441e', 'Como no voy – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/6e5484fe-b08c-4c8f-a75a-deba5604441e/rec-001.webm', now() - interval '6 days'),
-
--- Danza del sol (3 recordings)
-('11000000-0000-0000-0000-000000000042', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e5449b97-4aec-45ba-970a-445387d2e8ab', 'Danza del sol – Dawn', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e5449b97-4aec-45ba-970a-445387d2e8ab/rec-001.webm', now() - interval '21 days'),
-('11000000-0000-0000-0000-000000000043', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e5449b97-4aec-45ba-970a-445387d2e8ab', 'Danza del sol – Noon', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e5449b97-4aec-45ba-970a-445387d2e8ab/rec-002.webm', now() - interval '14 days'),
-('11000000-0000-0000-0000-000000000044', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'e5449b97-4aec-45ba-970a-445387d2e8ab', 'Danza del sol – Full', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/e5449b97-4aec-45ba-970a-445387d2e8ab/rec-003.webm', now() - interval '3 days'),
-
--- Defuma Con As Ervas Da Jurema (2 recordings)
-('11000000-0000-0000-0000-000000000045', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '31a12b76-5851-4651-9536-e7db2f76d785', 'Jurema – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/31a12b76-5851-4651-9536-e7db2f76d785/rec-001.webm', now() - interval '8 days'),
-('11000000-0000-0000-0000-000000000046', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '31a12b76-5851-4651-9536-e7db2f76d785', 'Jurema – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/31a12b76-5851-4651-9536-e7db2f76d785/rec-002.webm', now() - interval '5 days'),
-
--- Defuma esta casa (1 recording)
-('11000000-0000-0000-0000-000000000047', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '747aded6-4c50-4816-a748-62389ed7c408', 'Defuma esta casa – Practice', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/747aded6-4c50-4816-a748-62389ed7c408/rec-001.webm', now() - interval '2 days'),
-
--- Desde los Andes (2 recordings)
-('11000000-0000-0000-0000-000000000048', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'aa2e58fe-447b-470c-a763-8b4bd9abc9aa', 'Andes – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/aa2e58fe-447b-470c-a763-8b4bd9abc9aa/rec-001.webm', now() - interval '7 days'),
-('11000000-0000-0000-0000-000000000049', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'aa2e58fe-447b-470c-a763-8b4bd9abc9aa', 'Andes – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/aa2e58fe-447b-470c-a763-8b4bd9abc9aa/rec-002.webm', now() - interval '4 days'),
-
--- Agua De Estrellas (1 recording)
-('11000000-0000-0000-0000-000000000050', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'c4e141dd-9179-49d4-b249-bfcf5453bc21', 'Estrellas – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/c4e141dd-9179-49d4-b249-bfcf5453bc21/rec-001.webm', now() - interval '9 days'),
-
--- Agua de vida lluvia (3 recordings)
-('11000000-0000-0000-0000-000000000051', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd42ded1c-4af9-4ee2-97bf-9a6bcc521ce6', 'Lluvia – Rough', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d42ded1c-4af9-4ee2-97bf-9a6bcc521ce6/rec-001.webm', now() - interval '25 days'),
-('11000000-0000-0000-0000-000000000052', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd42ded1c-4af9-4ee2-97bf-9a6bcc521ce6', 'Lluvia – Refined', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d42ded1c-4af9-4ee2-97bf-9a6bcc521ce6/rec-002.webm', now() - interval '18 days'),
-('11000000-0000-0000-0000-000000000053', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'd42ded1c-4af9-4ee2-97bf-9a6bcc521ce6', 'Lluvia – Final', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/d42ded1c-4af9-4ee2-97bf-9a6bcc521ce6/rec-003.webm', now() - interval '2 days'),
-
--- Aguila Moteada (2 recordings)
-('11000000-0000-0000-0000-000000000054', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '87a15792-b298-48ad-a59a-fdab36958e08', 'Aguila – Take 1', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/87a15792-b298-48ad-a59a-fdab36958e08/rec-001.webm', now() - interval '12 days'),
-('11000000-0000-0000-0000-000000000055', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '87a15792-b298-48ad-a59a-fdab36958e08', 'Aguila – Take 2', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/87a15792-b298-48ad-a59a-fdab36958e08/rec-002.webm', now() - interval '10 days'),
-
--- En el camino (1 recording)
-('11000000-0000-0000-0000-000000000056', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '47efd643-eaea-4459-b8f8-7f64a0c8d02a', 'En el camino – Session', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/47efd643-eaea-4459-b8f8-7f64a0c8d02a/rec-001.webm', now() - interval '3 days')
-
-ON CONFLICT (id) DO NOTHING;
+  RAISE NOTICE 'Seeded 30 private recordings for Admin and 30 for Member.';
+END $$;


### PR DESCRIPTION
## Summary
- **Personal Rehearsal Recordings**: Private audio recording and uploading (, , , , , , , ) up to 25MB per file.
- **Visual Design**: Violet mic icons across cards, detail page link pills, and filter modal.
- **Filtering & Counter Badges**: Global and cross-filter aware  badges across all pages with automated 10-min caching and mutation invalidation.
- **Drag & Drop Custom Sorting**:  powered drag & drop reordering for rehearsal takes per song with Supabase  persistence.
- **Seed Data**: Dynamic 60 recordings total (30 for Admin, 30 for Member).

Closes #218