### PR TITLE
fix(song): call router.refresh() on song edit success to bust Next.js router cache

### DIFF
--- a/components/song/SongForm.tsx
+++ b/components/song/SongForm.tsx
@@ -341,6 +341,7 @@ const SongForm = ({ mode, initialData, songId, versionId }: SongFormProps) => {
             // Bust global filter counts (chords/melody/mine may have changed)
             queryClient.invalidateQueries({ queryKey: SONG_KEYS.globalFilterCounts() });
             const returnTo = mode === 'create' ? (searchParams.get('next') || '/') : `/songs/${id}`;
+            router.refresh();
             router.push(returnTo);
         },
         onError: (error: Error) => {


### PR DESCRIPTION
Ensures Next.js client router cache is revalidated immediately upon song create/edit submission.